### PR TITLE
docs: add auto-memory.md to structure index

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ claude-almanac/
 │   ├── mcp-servers.md
 │   ├── agents.md
 │   ├── plugins.md
+│   ├── auto-memory.md
 │   ├── memory-context.md
 │   ├── ide-integrations.md
 │   ├── security-sandbox.md


### PR DESCRIPTION
## Summary
- Add `auto-memory.md` entry to the structure index in `CLAUDE.md`
- Keeps the documented file listing in sync with the actual `features/` directory

## Test plan
- [ ] Verify markdown formatting passes (`mdformat --check`)