### PR TITLE
docs: add auto memory feature to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Comprehensive documentation of Claude Code's extensibility features and capabili
 | [Settings](./features/settings.md)                       | Configuration options  | Customize behavior, permissions, API                     |
 | [IDE Integrations](./features/ide-integrations.md)       | Editor support         | VSCode, JetBrains, Vim/Neovim, Chrome                    |
 | [Memory & Context](./features/memory-context.md)         | CLAUDE.md and context  | Persistent instructions, context management              |
+| [Auto Memory](./features/auto-memory.md)                 | MEMORY.md (automatic)  | Claude's self-maintained notes and learnings per project |
 | [Rules](./features/rules.md)                             | Modular memory files   | Path-conditional guidelines, organized by topic          |
 | [GitHub Actions](./features/github-actions.md)           | CI/CD integration      | PR review, issue-to-PR, automated workflows              |
 | [Headless/SDK](./features/headless-sdk.md)               | Programmatic usage     | CLI automation, custom agents, scripting                 |
@@ -213,6 +214,36 @@ ______________________________________________________________________
 ```
 
 [Full Documentation →](./features/memory-context.md)
+
+______________________________________________________________________
+
+### Auto Memory
+
+**Purpose**: Claude automatically saves learnings, patterns, and insights about your project.
+
+**Key Capabilities**:
+
+- Automatic memory recording by Claude as it works
+- Per-project storage in `~/.claude/projects/<project>/memory/`
+- `MEMORY.md` entrypoint (first 200 lines loaded at startup)
+- Topic files like `debugging.md`, `patterns.md` loaded on demand
+- Manage with `/memory` command or ask Claude to remember/forget
+
+**Quick Start**:
+
+```markdown
+# Tell Claude to remember
+"Remember that we use pnpm, not npm"
+"Save to memory that API tests require local Redis"
+
+# Tell Claude to forget
+"Forget that we use yarn"
+"Stop remembering the old API endpoint"
+```
+
+**Released**: Claude Code v2.1.59 (Feb 26, 2026)
+
+[Full Documentation →](./features/auto-memory.md)
 
 ______________________________________________________________________
 
@@ -424,6 +455,7 @@ ______________________________________________________________________
 | Settings            | Low                  | High        | Moderate            | Low            |
 | IDE Integrations    | Moderate             | High        | High                | Low            |
 | Memory/Context      | Low                  | High        | High                | Low            |
+| Auto Memory         | Low                  | High        | High                | None           |
 | Rules               | Low                  | High        | High                | Low            |
 | GitHub Actions      | High                 | Moderate    | High                | Low            |
 | Headless/SDK        | High                 | Low         | High                | Medium         |
@@ -445,6 +477,7 @@ ______________________________________________________________________
 | Settings       | `.claude/settings.json` | `/config`                          |
 | IDE            | Extension settings      | `Cmd+Esc`                          |
 | Memory         | `CLAUDE.md`             | `/memory`                          |
+| Auto Memory    | Auto-maintained         | `/memory` (toggle on/off)          |
 | Rules          | `.claude/rules/`        | `/memory`                          |
 | GitHub Actions | `.github/workflows/`    | `anthropics/claude-code-action@v1` |
 | Headless       | CLI flags               | `claude -p`                        |


### PR DESCRIPTION
## Summary
- Add auto memory feature to README.md navigation and summaries
- Added to Quick Navigation table with link to `features/auto-memory.md`
- Added dedicated feature summary section with capabilities and quick start
- Added to Quick Reference table and Feature Comparison Matrix

## Test plan
- [ ] Verify markdown formatting passes (`mdformat --check`)
- [ ] Verify all links work