### PR TITLE
fix: remove path filter from markdown check to support branch protection

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -2,8 +2,6 @@ name: Markdown Check
 
 on:
   pull_request:
-    paths:
-      - "**.md"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

Branch protection requires the \"Check Markdown Format\" workflow to pass, but this workflow has a path filter that only runs when `**.md` files are modified.

When PRs modify only non-markdown files (like `.gitignore`), the workflow doesn't run, and the PR cannot be merged due to missing required status checks.

## Solution

Remove the `paths` filter from the markdown workflow so it always runs. This ensures the required check is present for all PRs, regardless of which files are modified.

## Impact

- All PRs will now run markdown format checks
- Slightly more CI usage, but necessary for branch protection to work correctly
- Enables merging of PRs that don't modify markdown files