### PR TITLE
feat: add remote control feature documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ claude-almanac/
 │   ├── memory-context.md
 │   ├── ide-integrations.md
 │   ├── security-sandbox.md
+│   ├── remote-control.md
 │   ├── headless-sdk.md
 │   ├── github-actions.md
 │   └── additional-features.md

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Comprehensive documentation of Claude Code's extensibility features and capabili
 | [Auto Memory](./features/auto-memory.md)                 | MEMORY.md (automatic)  | Claude's self-maintained notes and learnings per project |
 | [Rules](./features/rules.md)                             | Modular memory files   | Path-conditional guidelines, organized by topic          |
 | [GitHub Actions](./features/github-actions.md)           | CI/CD integration      | PR review, issue-to-PR, automated workflows              |
+| [Remote Control](./features/remote-control.md)           | Mobile/web access      | Control terminal sessions from phone, tablet, or browser |
 | [Headless/SDK](./features/headless-sdk.md)               | Programmatic usage     | CLI automation, custom agents, scripting                 |
 | [Plugins](./features/plugins.md)                         | Shareable packages     | Distribute tools, LSP servers, team standardization      |
 | [Security & Sandbox](./features/security-sandbox.md)     | Isolation and controls | Secure execution, network isolation, enterprise policies |
@@ -340,6 +341,33 @@ ______________________________________________________________________
 
 ______________________________________________________________________
 
+### Remote Control
+
+**Purpose**: Control a terminal Claude Code session from your phone, tablet, or any browser.
+
+**Key Capabilities**:
+
+- Session stays local, control from anywhere via claude.ai or mobile app
+- QR code, URL, or app-based connection
+- Syncs conversation across all connected devices
+- Server mode for multiple concurrent sessions
+
+**Quick Start**:
+
+```bash
+# Start remote control
+claude remote-control
+
+# Or from an existing session
+/remote-control My Project
+```
+
+**Requirements**: Claude Code v2.1.51+, Pro/Max/Team/Enterprise plan.
+
+[Full Documentation →](./features/remote-control.md)
+
+______________________________________________________________________
+
 ### Headless Mode and Agent SDK
 
 **Purpose**: Run Claude Code programmatically for scripting, custom agents, and automation.
@@ -493,6 +521,7 @@ ______________________________________________________________________
 | Auto Memory         | Low                  | High        | High                | None           |
 | Rules               | Low                  | High        | High                | Low            |
 | GitHub Actions      | High                 | Moderate    | High                | Low            |
+| Remote Control      | Moderate             | High        | High                | Low            |
 | Headless/SDK        | High                 | Low         | High                | Medium         |
 | Plugins             | High                 | Moderate    | High                | Medium         |
 | Security/Sandbox    | Low                  | Moderate    | Low                 | Low            |
@@ -516,6 +545,7 @@ ______________________________________________________________________
 | Auto Memory    | Auto-maintained         | `/memory` (toggle on/off)                     |
 | Rules          | `.claude/rules/`        | `/memory`                                     |
 | GitHub Actions | `.github/workflows/`    | `anthropics/claude-code-action@v1`            |
+| Remote Control | CLI flag                | `claude remote-control`                       |
 | Headless       | CLI flags               | `claude -p`                                   |
 | Plugins        | `.claude/settings.json` | `/plugin`                                     |
 | Sandbox        | `.claude/settings.json` | `/sandbox`                                    |
@@ -532,6 +562,7 @@ ______________________________________________________________________
 1. **Want automation?** → Check out [Hooks](./features/hooks.md) for automatic actions
 1. **Need external tools?** → Set up [MCP Servers](./features/mcp-servers.md)
 1. **Building workflows?** → Create [Skills](./features/skills.md) for reusable commands
+1. **On the go?** → Set up [Remote Control](./features/remote-control.md) for phone/tablet access
 1. **Running in CI/CD?** → Use [GitHub Actions](./features/github-actions.md) or [Headless Mode](./features/headless-sdk.md)
 1. **Validating configs?** → Set up [Testing](./features/testing.md) for automated validation
 1. **Parallel collaboration?** → Set up [Agent Teams](./features/agent-teams.md) for multi-instance work

--- a/features/remote-control.md
+++ b/features/remote-control.md
@@ -1,0 +1,70 @@
+# Claude Code Remote Control
+
+Control a terminal Claude Code session from your phone, tablet, or any browser. Claude keeps running entirely on your machine while you interact from anywhere.
+
+## Overview
+
+Remote Control bridges your local Claude Code session to [claude.ai/code](https://claude.ai/code) and the Claude mobile app (iOS/Android). All traffic travels through TLS to Anthropic's servers, so no port forwarding or VPN is needed.
+
+Key properties:
+
+- Code execution stays local (nothing moves to the cloud)
+- Conversation syncs across all connected devices
+- Works alongside local terminal input (interactive mode)
+
+## Requirements
+
+- Claude Code v2.1.51 or later
+- Pro, Max, Team, or Enterprise plan (not API keys)
+- Authenticated with claude.ai (`/login` if needed)
+- Workspace trust accepted (run `claude` in your project once)
+
+## Starting a Session
+
+### Server Mode (recommended for multiple sessions)
+
+```bash
+claude remote-control
+```
+
+Press spacebar to display a QR code in the terminal.
+
+### Interactive Mode
+
+```bash
+claude --remote-control "My Project Name"
+```
+
+You can type locally and remotely at the same time.
+
+### From an Existing Session
+
+```
+/remote-control My Project Name
+```
+
+## Connecting from Another Device
+
+Once Remote Control is running:
+
+| Method      | How                                                                                                               |
+| ----------- | ----------------------------------------------------------------------------------------------------------------- |
+| QR code     | Scan the terminal QR code with your phone camera                                                                  |
+| Session URL | Open the URL shown in your terminal in any browser                                                                |
+| Claude app  | Open [claude.ai/code](https://claude.ai/code) or the mobile app and find the session by name (green dot = online) |
+
+## Team and Enterprise
+
+Remote Control is **off by default** for Team and Enterprise plans. An organization admin must enable it at [claude.ai/admin-settings/claude-code](https://claude.ai/admin-settings/claude-code).
+
+## Limitations
+
+| Limitation              | Detail                                                                                                        |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Terminal must stay open | Closing the terminal ends the session                                                                         |
+| Network timeout         | Sessions time out after roughly 10 minutes of network unavailability                                          |
+| One remote per process  | In interactive mode each instance supports one remote connection. Use server mode with `--spawn` for multiple |
+
+## References
+
+- [Remote Control Docs](https://code.claude.com/docs/en/remote-control.md)


### PR DESCRIPTION
## Summary

- Add `features/remote-control.md` documenting the Remote Control feature (control terminal sessions from phone/tablet/browser)
- Add Remote Control entry to README navigation table, feature summary, comparison matrix, and quick reference
- Update CLAUDE.md structure listing

## Test plan

- [ ] Verify markdown passes `mdformat --check`
- [ ] Verify all links in README point to correct files
- [ ] Review feature doc for accuracy against official docs