### PR TITLE
fix: clarify remote control requires claude.ai auth only

### DIFF
--- a/features/remote-control.md
+++ b/features/remote-control.md
@@ -15,9 +15,11 @@ Key properties:
 ## Requirements
 
 - Claude Code v2.1.51 or later
-- Pro, Max, Team, or Enterprise plan (not API keys)
+- Pro, Max, Team, or Enterprise plan via claude.ai
 - Authenticated with claude.ai (`/login` if needed)
 - Workspace trust accepted (run `claude` in your project once)
+
+**Not supported**: API keys, Vertex AI, Bedrock, or Foundry authentication. Remote Control requires claude.ai OAuth. If you have `CLAUDE_CODE_USE_VERTEX` or `CLAUDE_CODE_USE_BEDROCK` set, Remote Control will not activate.
 
 ## Starting a Session
 


### PR DESCRIPTION
## Summary

- Clarify that Remote Control does not work with Vertex AI, Bedrock, Foundry, or API key authentication
- Note that `CLAUDE_CODE_USE_VERTEX` / `CLAUDE_CODE_USE_BEDROCK` env vars prevent activation

## Test plan

- [ ] Verify markdown passes format check