### PR TITLE
docs: add reference links to pricing and agent teams pages

### DIFF
--- a/features/agent-teams.md
+++ b/features/agent-teams.md
@@ -326,3 +326,4 @@ claude -p "Review the codebase" --max-budget-usd 10.00
 - [Agent Teams Documentation](https://code.claude.com/docs/en/agent-teams)
 - [Subagents Documentation](https://code.claude.com/docs/en/sub-agents)
 - [Hooks Documentation](https://code.claude.com/docs/en/hooks)
+- [Agent Teams: Environment Setup](agent-teams-setup.md) - Ghostty, tmux, Starship, and VS Code integration

--- a/features/pricing.md
+++ b/features/pricing.md
@@ -123,3 +123,4 @@ Automode requires all of the following:
 - [Team Plan overview](https://support.claude.com/en/articles/9266767-what-is-the-team-plan)
 - [Purchase and manage Team seats](https://support.claude.com/en/articles/12004354-purchase-and-manage-seats-on-team-plans)
 - [Auto mode blog post](https://claude.com/blog/auto-mode)
+- [Agent Teams setup guide](https://github.com/asivura/claude-almanac/blob/main/features/agent-teams.md)


### PR DESCRIPTION
## Summary

- Add agent teams setup guide link to agent-teams.md references
- Add agent teams guide link to pricing.md references