### PR TITLE
feat: add checkpointing and code review documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,8 @@ claude-almanac/
 │   ├── github-actions.md
 │   ├── pricing.md
 │   ├── scheduled-tasks.md
+│   ├── checkpointing.md
+│   ├── code-review.md
 │   └── additional-features.md
 ```
 

--- a/features/checkpointing.md
+++ b/features/checkpointing.md
@@ -1,0 +1,93 @@
+# Claude Code Checkpointing
+
+Claude Code automatically tracks file edits as you work, allowing you to quickly undo changes and rewind to previous states.
+
+## How Checkpoints Work
+
+As you work with Claude, checkpointing captures the state of your code before each edit. This safety net lets you pursue ambitious, wide-scale tasks knowing you can always return to a prior code state.
+
+### Automatic Tracking
+
+- Every user prompt creates a new checkpoint
+- Checkpoints persist across sessions (accessible in resumed conversations)
+- Automatically cleaned up along with sessions after 30 days (configurable)
+- Only tracks changes made by Claude's file editing tools (not bash commands)
+
+### Opening the Rewind Menu
+
+Press `Esc` twice (`Esc` + `Esc`) or use the `/rewind` command. A scrollable list shows each of your prompts from the session.
+
+### Rewind Actions
+
+Select a point in the session, then choose an action:
+
+| Action                            | Code reverted | Conversation reverted | Notes                                       |
+| --------------------------------- | ------------- | --------------------- | ------------------------------------------- |
+| **Restore code and conversation** | Yes           | Yes                   | Full rewind to that point                   |
+| **Restore conversation**          | No            | Yes                   | Keeps current code, rewinds chat            |
+| **Restore code**                  | Yes           | No                    | Reverts files, keeps conversation           |
+| **Summarize from here**           | No            | Compressed            | Replaces messages with AI-generated summary |
+| **Never mind**                    | No            | No                    | Returns to message list                     |
+
+After restoring conversation or summarizing, the original prompt from the selected message is restored into the input field so you can re-send or edit it.
+
+### Restore vs. Summarize
+
+The three restore options revert state. **Summarize from here** works differently:
+
+- Messages before the selected point stay intact
+- The selected message and all subsequent messages are replaced with a compact AI-generated summary
+- No files on disk are changed
+- Original messages are preserved in the session transcript (Claude can still reference them)
+- You can type optional instructions to guide what the summary focuses on
+
+This is similar to `/compact`, but targeted: you keep early context in full detail and only compress the parts using up space.
+
+> To branch off and try a different approach while preserving the original session intact, use fork instead (`claude --continue --fork-session`).
+
+## VS Code Integration
+
+The VS Code extension supports checkpoints with hover-based rewind. Hover over any message to reveal the rewind button, then choose:
+
+- **Fork conversation from here**: Start a new conversation branch from this message while keeping all code changes
+- **Rewind code to here**: Revert file changes back to this point while keeping the full conversation history
+- **Fork conversation and rewind code**: Start a new branch and revert file changes to this point
+
+## Common Use Cases
+
+- **Exploring alternatives**: Try different implementations without losing your starting point
+- **Recovering from mistakes**: Quickly undo changes that introduced bugs or broke functionality
+- **Iterating on features**: Experiment with variations knowing you can revert to working states
+- **Freeing context space**: Summarize a verbose debugging session from the midpoint forward, keeping initial instructions intact
+
+## Limitations
+
+### Bash Command Changes Not Tracked
+
+Checkpointing does not track files modified by bash commands:
+
+```bash
+rm file.txt
+mv old.txt new.txt
+cp source.txt dest.txt
+```
+
+These file modifications cannot be undone through rewind. Only direct file edits made through Claude's file editing tools are tracked.
+
+### External Changes Not Tracked
+
+Only files edited within the current session are tracked. Manual changes you make outside of Claude Code and edits from other concurrent sessions are normally not captured, unless they modify the same files as the current session.
+
+### Not a Replacement for Version Control
+
+Checkpoints are designed for quick, session-level recovery:
+
+- Continue using Git for commits, branches, and long-term history
+- Think of checkpoints as "local undo" and Git as "permanent history"
+- Checkpoints complement but don't replace proper version control
+
+## References
+
+- [Checkpointing](https://code.claude.com/docs/en/checkpointing)
+- [Interactive Mode](https://code.claude.com/docs/en/interactive-mode)
+- [Built-in Commands](https://code.claude.com/docs/en/commands)

--- a/features/code-review.md
+++ b/features/code-review.md
@@ -1,0 +1,155 @@
+# Claude Code Review
+
+> **Status**: Research preview. Available for Team and Enterprise subscriptions. Not available with Zero Data Retention enabled.
+
+Automated PR review that catches logic errors, security vulnerabilities, and regressions using multi-agent analysis of your full codebase.
+
+## How Reviews Work
+
+When a review runs, multiple agents analyze the diff and surrounding code in parallel on Anthropic infrastructure. Each agent looks for a different class of issue, then a verification step checks candidates against actual code behavior to filter out false positives. Results are deduplicated, ranked by severity, and posted as inline comments on specific lines.
+
+Reviews complete in 20 minutes on average, scaling with PR size and complexity.
+
+### What Code Review Checks
+
+By default, Code Review focuses on **correctness**: bugs that would break production, not formatting preferences or missing test coverage. You can expand scope with CLAUDE.md and REVIEW.md guidance files.
+
+### Severity Levels
+
+| Marker | Severity     | Meaning                                                             |
+| ------ | ------------ | ------------------------------------------------------------------- |
+| 🔴     | Important    | A bug that should be fixed before merging                           |
+| 🟡     | Nit          | A minor issue, worth fixing but not blocking                        |
+| 🟣     | Pre-existing | A bug that exists in the codebase but was not introduced by this PR |
+
+Findings include a collapsible extended reasoning section explaining why Claude flagged the issue and how it verified the problem.
+
+### Check Run Output
+
+Each review populates a **Claude Code Review** check run alongside your CI checks:
+
+- Summary table of all findings sorted by severity
+- Annotations in the **Files changed** tab on relevant diff lines
+- Machine-readable severity JSON in the last line of Details text (parseable with `gh` and `jq`)
+- Always completes with **neutral** conclusion (never blocks merging)
+
+```bash
+# Parse severity counts programmatically
+gh api repos/OWNER/REPO/check-runs/CHECK_RUN_ID \
+  --jq '.output.text | split("bughunter-severity: ")[1] | split(" -->")[0] | fromjson'
+# Returns: {"normal": 2, "nit": 1, "pre_existing": 0}
+```
+
+## Setup
+
+An admin enables Code Review once for the organization.
+
+1. Go to [claude.ai/admin-settings/claude-code](https://claude.ai/admin-settings/claude-code), find Code Review section
+1. Click **Setup** to begin GitHub App installation
+1. Install the Claude GitHub App (requires Contents, Issues, Pull Requests permissions)
+1. Select repositories to enable
+1. Set review triggers per repository
+
+### Review Triggers
+
+| Trigger                    | Behavior                                                      |
+| -------------------------- | ------------------------------------------------------------- |
+| **Once after PR creation** | Review runs once when PR is opened or marked ready for review |
+| **After every push**       | Review runs on every push, auto-resolves fixed issues         |
+| **Manual**                 | Reviews only when someone comments `@claude review` on the PR |
+
+## Manual Triggers
+
+Two comment commands start reviews on demand, regardless of configured trigger:
+
+| Command               | Effect                                                                  |
+| --------------------- | ----------------------------------------------------------------------- |
+| `@claude review`      | Starts review and subscribes PR to push-triggered reviews going forward |
+| `@claude review once` | Starts a single review without subscribing to future pushes             |
+
+Requirements:
+
+- Post as a top-level PR comment (not inline on a diff line)
+- Command at the start of the comment
+- You must have owner, member, or collaborator access
+- PR must be open
+
+Manual triggers work on draft PRs. If a review is already running, the request is queued.
+
+## Customizing Reviews
+
+Code Review reads two files from your repository:
+
+### CLAUDE.md
+
+Shared project instructions used across all Claude Code tasks. Newly-introduced violations are flagged as nit-level findings. Works bidirectionally: if a PR makes CLAUDE.md statements outdated, Claude flags that the docs need updating too. Reads CLAUDE.md at every directory level (subdirectory rules apply only to files under that path).
+
+### REVIEW.md
+
+Review-only guidance at the repository root. Use for:
+
+- Team style guidelines ("prefer early returns over nested conditionals")
+- Language/framework conventions not covered by linters
+- Things to always flag ("new API routes must have integration tests")
+- Things to skip ("don't comment on generated code under `/gen/`")
+
+```markdown
+# Code Review Guidelines
+
+## Always check
+- New API endpoints have corresponding integration tests
+- Database migrations are backward-compatible
+- Error messages don't leak internal details to users
+
+## Style
+- Prefer `match` statements over chained `isinstance` checks
+- Use structured logging, not f-string interpolation in log calls
+
+## Skip
+- Generated files under `src/gen/`
+- Formatting-only changes in `*.lock` files
+```
+
+## Pricing
+
+- Billed based on token usage, averaging **$15-25 per review**
+- Scales with PR size, codebase complexity, and verification depth
+- Billed separately through extra usage (not against plan's included usage)
+- Costs apply regardless of Bedrock/Vertex usage for other features
+- Set monthly spend cap at [claude.ai/admin-settings/usage](https://claude.ai/admin-settings/usage)
+
+Cost by trigger:
+
+- **Once after PR creation**: One review per PR
+- **After every push**: Multiplied by number of pushes
+- **Manual**: No cost until `@claude review` is posted
+
+### Usage Analytics
+
+View activity at [claude.ai/analytics/code-review](https://claude.ai/analytics/code-review):
+
+- PRs reviewed (daily count)
+- Cost weekly
+- Feedback (auto-resolved comments)
+- Repository breakdown
+
+## Troubleshooting
+
+### Retrigger a Failed Review
+
+When a review hits an internal error or timeout, the check run title shows "Code review encountered an error" or "Code review timed out." Comment `@claude review once` to start a fresh review. The GitHub **Re-run** button does not retrigger Code Review.
+
+### Missing Inline Comments
+
+If the check run reports findings but no inline comments appear:
+
+- **Check run Details**: Lists every finding regardless of inline comment status
+- **Files changed annotations**: Findings render as annotations on diff lines
+- **Review body**: Findings for lines that moved appear under "Additional findings" in the review body
+
+## References
+
+- [Code Review](https://code.claude.com/docs/en/code-review)
+- [GitHub Actions](https://code.claude.com/docs/en/github-actions)
+- [GitLab CI/CD](https://code.claude.com/docs/en/gitlab-ci-cd)
+- [Plugins](https://code.claude.com/docs/en/discover-plugins) (includes `code-review` plugin for local pre-push reviews)


### PR DESCRIPTION
## Summary
- Create `features/checkpointing.md` (93 lines): auto-tracking, rewind menu (Esc×2, /rewind), five rewind actions with comparison table, restore vs summarize, VS Code integration (fork/rewind/both), limitations
- Create `features/code-review.md` (155 lines): multi-agent PR analysis, severity levels, review triggers, @claude review commands, CLAUDE.md/REVIEW.md customization, check run output with machine-readable JSON, pricing ($15-25/review), analytics dashboard, troubleshooting
- Update CLAUDE.md structure listing

Closes #35 #36

## Sources
- [Checkpointing](https://code.claude.com/docs/en/checkpointing)
- [Code Review](https://code.claude.com/docs/en/code-review)