### PR TITLE
feat: add GitLab CI/CD and voice dictation documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,10 @@ claude-almanac/
 │   ├── scheduled-tasks.md
 │   ├── checkpointing.md
 │   ├── code-review.md
+│   ├── channels.md
+│   ├── slack-integration.md
+│   ├── gitlab-cicd.md
+│   ├── voice-dictation.md
 │   └── additional-features.md
 ```
 

--- a/features/gitlab-cicd.md
+++ b/features/gitlab-cicd.md
@@ -1,0 +1,178 @@
+# Claude Code GitLab CI/CD
+
+> **Status**: Beta. Maintained by GitLab. Built on the Claude Code CLI and Agent SDK.
+
+Integrate Claude Code into GitLab CI/CD pipelines to automate code changes, create MRs from issues, and respond to review comments.
+
+## Capabilities
+
+- Create and update MRs from issue descriptions or comments
+- Implement features in a branch and open MRs
+- Fix bugs identified by tests or comments
+- Analyze performance regressions and propose optimizations
+- Respond to follow-up comments to iterate on changes
+
+## How It Works
+
+1. **Event-driven**: GitLab listens for triggers (e.g., `@claude` mentions in issues, MRs, or review threads). The job collects context and runs Claude Code.
+1. **Provider abstraction**: Choose Claude API (SaaS), AWS Bedrock (OIDC), or Google Vertex AI (Workload Identity Federation).
+1. **Sandboxed execution**: Each interaction runs in an isolated container. Changes flow through MRs so reviewers see diffs and approvals still apply.
+
+## Quick Setup
+
+### 1. Add API Key
+
+**Settings > CI/CD > Variables**: Add `ANTHROPIC_API_KEY` (masked, protected as needed).
+
+### 2. Add CI Job
+
+```yaml
+stages:
+  - ai
+
+claude:
+  stage: ai
+  image: node:24-alpine3.21
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "web"'
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+  variables:
+    GIT_STRATEGY: fetch
+  before_script:
+    - apk update
+    - apk add --no-cache git curl bash
+    - curl -fsSL https://claude.ai/install.sh | bash
+  script:
+    - /bin/gitlab-mcp-server || true
+    - >
+      claude
+      -p "${AI_FLOW_INPUT:-'Review this MR and implement the requested changes'}"
+      --permission-mode acceptEdits
+      --allowedTools "Bash Read Edit Write mcp__gitlab"
+      --debug
+```
+
+### 3. Test
+
+Run manually from **CI/CD > Pipelines**, or trigger from an MR.
+
+## Enterprise Providers
+
+### AWS Bedrock
+
+Prerequisites:
+
+- AWS account with Bedrock access to Claude models
+- GitLab configured as OIDC identity provider in AWS IAM
+- IAM role with Bedrock permissions, trust policy restricted to your project/refs
+
+Required CI/CD variables:
+
+- `AWS_ROLE_TO_ASSUME` (role ARN)
+- `AWS_REGION` (Bedrock region)
+
+The job exchanges the GitLab OIDC token for temporary AWS credentials at runtime (no static keys).
+
+### Google Vertex AI
+
+Prerequisites:
+
+- GCP project with Vertex AI API enabled
+- Workload Identity Federation configured to trust GitLab OIDC
+- Dedicated service account with Vertex AI roles
+
+Required CI/CD variables:
+
+- `GCP_WORKLOAD_IDENTITY_PROVIDER` (full resource name)
+- `GCP_SERVICE_ACCOUNT` (service account email)
+- `CLOUD_ML_REGION` (e.g., `us-east5`)
+
+Authenticates via WIF without storing service account keys.
+
+## Trigger Patterns
+
+| Trigger            | How                                                          |
+| ------------------ | ------------------------------------------------------------ |
+| Manual             | Run from CI/CD > Pipelines                                   |
+| MR events          | `$CI_PIPELINE_SOURCE == "merge_request_event"`               |
+| `@claude` mentions | Webhook on "Comments (notes)" calls pipeline trigger API     |
+| Web/API triggers   | Use `AI_FLOW_INPUT`, `AI_FLOW_CONTEXT`, `AI_FLOW_EVENT` vars |
+
+## Example Use Cases
+
+**Turn issues into MRs:**
+
+```text
+@claude implement this feature based on the issue description
+```
+
+**Get implementation help:**
+
+```text
+@claude suggest a concrete approach to cache the results of this API call
+```
+
+**Fix bugs:**
+
+```text
+@claude fix the TypeError in the user dashboard component
+```
+
+## Configuration
+
+### CLAUDE.md
+
+Create a `CLAUDE.md` at repository root to define coding standards and conventions. Claude reads this during runs.
+
+### Common Parameters
+
+| Parameter         | Purpose                             |
+| ----------------- | ----------------------------------- |
+| `-p` / `prompt`   | Inline instructions                 |
+| `prompt_file`     | Instructions from a file            |
+| `max_turns`       | Limit back-and-forth iterations     |
+| `timeout_minutes` | Limit total execution time          |
+| `--allowedTools`  | Restrict which tools Claude can use |
+
+## Security
+
+- Each job runs in an isolated container with restricted network access
+- Changes flow through MRs (reviewers see every diff)
+- Branch protection and approval rules apply to AI-generated code
+- Workspace-scoped permissions constrain writes
+- Use OIDC/WIF where possible (no long-lived keys)
+- Never commit API keys or credentials to your repository
+
+## Cost Considerations
+
+- **GitLab Runner time**: Consumes compute minutes on your runners
+- **API tokens**: Usage varies by task complexity and codebase size
+- Use specific `@claude` commands to reduce unnecessary turns
+- Set appropriate `max_turns` and job timeout values
+- Limit concurrency to control parallel runs
+
+## Troubleshooting
+
+### Claude Not Responding to @claude
+
+- Verify pipeline is being triggered
+- Ensure CI/CD variables are present and unmasked
+- Check comment contains `@claude` (not `/claude`)
+
+### Job Can't Write Comments or Open MRs
+
+- Ensure `CI_JOB_TOKEN` has sufficient permissions, or use a Project Access Token with `api` scope
+- Check `mcp__gitlab` tool is enabled in `--allowedTools`
+
+### Authentication Errors
+
+- **Claude API**: Confirm `ANTHROPIC_API_KEY` is valid
+- **Bedrock**: Verify OIDC config, role impersonation, region, and model availability
+- **Vertex**: Verify WIF configuration and service account permissions
+
+## References
+
+- [GitLab CI/CD](https://code.claude.com/docs/en/gitlab-ci-cd)
+- [GitHub Actions](https://code.claude.com/docs/en/github-actions)
+- [Agent SDK](https://platform.claude.com/docs/en/agent-sdk/overview)
+- [GitLab Support Issue](https://gitlab.com/gitlab-org/gitlab/-/issues/573776)

--- a/features/voice-dictation.md
+++ b/features/voice-dictation.md
@@ -1,0 +1,108 @@
+# Claude Code Voice Dictation
+
+Use push-to-talk voice dictation to speak prompts instead of typing them. Speech is transcribed live into the prompt input, and you can mix voice and typing in the same message.
+
+> Requires Claude Code v2.1.69 or later.
+
+## Requirements
+
+- **Authentication**: Claude.ai account only. Not available with API key, Bedrock, Vertex, or Foundry.
+- **Local microphone**: Does not work in remote environments (Claude Code on the web, SSH). WSL requires WSLg (WSL2 on Windows 11).
+- **Audio recording**: Built-in native module on macOS, Linux, and Windows. On Linux, falls back to `arecord` (ALSA) or `rec` (SoX) if the native module can't load.
+- **Transcription**: Audio is streamed to Anthropic's servers. Not processed locally.
+
+## Enabling Voice Dictation
+
+```text
+/voice
+Voice mode enabled. Hold Space to record. Dictation language: en (/config to change).
+```
+
+Persists across sessions. Run `/voice` again to disable, or set in settings:
+
+```json
+{
+  "voiceEnabled": true
+}
+```
+
+First-time use triggers a microphone check. On macOS, this prompts for terminal microphone permission.
+
+## Recording
+
+Hold `Space` to start recording:
+
+1. **Warmup**: Footer shows `keep holding...` while detecting held key via key-repeat
+1. **Recording**: Live waveform displays, speech appears dimmed in prompt
+1. **Release**: Transcript finalizes and inserts at cursor position
+
+Single `Space` tap still types a space normally. Mix typing and dictation freely:
+
+```text
+> refactor the auth middleware to [hold Space, speak] use the new token validation helper
+```
+
+Transcription is tuned for coding vocabulary: `regex`, `OAuth`, `JSON`, `localhost`, etc. Your project name and git branch are added as recognition hints automatically.
+
+## Push-to-Talk Key
+
+Default is `Space`. Rebind in `~/.claude/keybindings.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "context": "Chat",
+      "bindings": {
+        "meta+k": "voice:pushToTalk",
+        "space": null
+      }
+    }
+  ]
+}
+```
+
+Modifier combinations (e.g., `meta+k`) start recording on the first keypress with no warmup. Avoid bare letter keys since they type during warmup.
+
+## Dictation Language
+
+Uses the `language` setting (same as Claude's response language). Defaults to English if unset.
+
+```json
+{
+  "language": "japanese"
+}
+```
+
+Supports BCP 47 codes or language names. If the language isn't supported, dictation falls back to English with a warning.
+
+### Supported Languages
+
+| Language   | Code | Language   | Code |
+| ---------- | ---- | ---------- | ---- |
+| Czech      | `cs` | Korean     | `ko` |
+| Danish     | `da` | Norwegian  | `no` |
+| Dutch      | `nl` | Polish     | `pl` |
+| English    | `en` | Portuguese | `pt` |
+| French     | `fr` | Russian    | `ru` |
+| German     | `de` | Spanish    | `es` |
+| Greek      | `el` | Swedish    | `sv` |
+| Hindi      | `hi` | Turkish    | `tr` |
+| Indonesian | `id` | Ukrainian  | `uk` |
+| Italian    | `it` | Japanese   | `ja` |
+
+## Troubleshooting
+
+| Issue                                     | Fix                                                                          |
+| ----------------------------------------- | ---------------------------------------------------------------------------- |
+| "Voice mode requires a Claude.ai account" | Run `/login` to sign in with Claude.ai (not API key or third-party provider) |
+| "Microphone access is denied"             | Grant microphone permission in system settings, then run `/voice` again      |
+| "No audio recording tool found" (Linux)   | Install SoX: `sudo apt-get install sox`                                      |
+| Nothing happens when holding Space        | Ensure voice is enabled (`/voice`). Check terminal sends key-repeat events   |
+| Transcription garbled or wrong language   | Set correct language in `/config`                                            |
+
+## References
+
+- [Voice Dictation](https://code.claude.com/docs/en/voice-dictation)
+- [Keyboard Shortcuts](https://code.claude.com/docs/en/keybindings)
+- [Settings](https://code.claude.com/docs/en/settings)


### PR DESCRIPTION
## Summary
- Create `features/gitlab-cicd.md` (178 lines): event-driven pipelines, quick setup, enterprise providers (Bedrock OIDC, Vertex WIF), trigger patterns, security, cost considerations
- Create `features/voice-dictation.md` (108 lines): push-to-talk, recording workflow, coding vocabulary, keybinding customization, 20 languages, troubleshooting
- Update CLAUDE.md structure listing

Closes #40 #38

## Sources
- [GitLab CI/CD](https://code.claude.com/docs/en/gitlab-ci-cd)
- [Voice Dictation](https://code.claude.com/docs/en/voice-dictation)