### PR TITLE
feat: add computer use and ultraplan documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,8 @@ claude-almanac/
 │   ├── slack-integration.md
 │   ├── gitlab-cicd.md
 │   ├── voice-dictation.md
+│   ├── computer-use.md
+│   ├── ultraplan.md
 │   └── additional-features.md
 ```
 

--- a/features/computer-use.md
+++ b/features/computer-use.md
@@ -1,0 +1,136 @@
+# Claude Code Computer Use
+
+> **Status**: Research preview. Requires Pro or Max plan. macOS only (CLI). Claude Code v2.1.85 or later. Not available on Team or Enterprise plans, non-interactive mode (`-p`), or third-party providers (Bedrock, Vertex, Foundry).
+
+Let Claude open apps, control your screen, click, type, and take screenshots on macOS directly from the CLI. Build and validate native apps, debug visual issues, test GUI flows, and drive tools that have no CLI or API.
+
+## What You Can Do
+
+- **Build and validate native apps**: Claude writes Swift, compiles it, launches the app, clicks through every control, and verifies it works
+- **End-to-end UI testing**: Point Claude at a local Electron app and say "test the onboarding flow." Claude opens it, clicks through signup, screenshots each step. No Playwright or test harness needed
+- **Debug visual and layout issues**: Claude resizes windows, reproduces bugs, screenshots the broken state, patches CSS, and verifies the fix
+- **Drive GUI-only tools**: Interact with design tools, hardware control panels, the iOS Simulator, or proprietary apps without a CLI or API
+
+## When Computer Use Applies
+
+Claude tries the most precise tool first and falls back to computer use only when nothing else can reach the task:
+
+1. **MCP server** for the service (if configured)
+1. **Bash** for shell commands
+1. **Claude in Chrome** for browser work (if configured)
+1. **Computer use** for native apps, simulators, and tools without an API
+
+## Enabling Computer Use
+
+Computer use is a built-in MCP server called `computer-use`, disabled by default.
+
+1. Run `/mcp` in an interactive session
+1. Find `computer-use` in the server list and select **Enable**
+1. The setting persists per project
+
+On first use, macOS prompts for two permissions:
+
+- **Accessibility**: lets Claude click, type, and scroll
+- **Screen Recording**: lets Claude see what's on your screen
+
+Grant both in System Settings. macOS may require restarting Claude Code after granting Screen Recording.
+
+## App Approval Per Session
+
+Enabling the server does not grant access to every app. The first time Claude needs a specific app in a session, a prompt shows:
+
+- Which apps Claude wants to control
+- Any extra permissions requested (e.g., clipboard access)
+- How many other apps will be hidden while Claude works
+
+Choose **Allow for this session** or **Deny**. Approvals last for the current session only.
+
+### App Warnings
+
+Apps with broad reach show extra warnings:
+
+| Warning                    | Applies to                                     |
+| -------------------------- | ---------------------------------------------- |
+| Equivalent to shell access | Terminal, iTerm, VS Code, Warp, and other IDEs |
+| Can read or write any file | Finder                                         |
+| Can change system settings | System Settings                                |
+
+Claude's level of control also varies by app category: browsers and trading platforms are view-only, terminals and IDEs are click-only, and everything else gets full control.
+
+## How Claude Works on Your Screen
+
+### One Session at a Time
+
+Computer use holds a machine-wide lock. If another session is already using your computer, new attempts fail with a message identifying which session holds the lock.
+
+### Apps Are Hidden While Claude Works
+
+When Claude starts controlling your screen, other visible apps are hidden so Claude interacts only with approved apps. Your terminal stays visible and is excluded from screenshots, so you can watch and Claude never sees its own output. Hidden apps restore automatically when the turn finishes.
+
+### Stop at Any Time
+
+A macOS notification appears: "Claude is using your computer - press Esc to stop." Press `Esc` anywhere to abort immediately, or press `Ctrl+C` in the terminal. Claude releases the lock, unhides apps, and returns control.
+
+## Safety
+
+Unlike the sandboxed Bash tool, computer use runs on your actual desktop with access to the apps you approve. Built-in guardrails:
+
+- **Per-app approval**: Claude can only control apps you've approved in the current session
+- **Sentinel warnings**: apps granting shell, filesystem, or system settings access are flagged
+- **Terminal excluded from screenshots**: Claude never sees your terminal window
+- **Global escape**: `Esc` aborts computer use from anywhere (key press is consumed, so prompt injection can't use it to dismiss dialogs)
+- **Lock file**: only one session can control your machine at a time
+
+## Example Workflows
+
+### Validate a Native Build
+
+```text
+Build the MenuBarStats target, launch it, open the preferences window,
+and verify the interval slider updates the label. Screenshot the
+preferences window when you're done.
+```
+
+Claude runs `xcodebuild`, launches the app, interacts with the UI, and reports findings.
+
+### Reproduce a Layout Bug
+
+```text
+The settings modal clips its footer on narrow windows. Resize the app
+window down until you can reproduce it, screenshot the clipped state,
+then check the CSS for the modal container.
+```
+
+### Test a Simulator Flow
+
+```text
+Open the iOS Simulator, launch the app, tap through the onboarding
+screens, and tell me if any screen takes more than a second to load.
+```
+
+## CLI vs Desktop App
+
+| Feature            | Desktop                                        | CLI                             |
+| ------------------ | ---------------------------------------------- | ------------------------------- |
+| Platforms          | macOS and Windows                              | macOS only                      |
+| Enable             | Toggle in Settings > General (Desktop app)     | Enable `computer-use` in `/mcp` |
+| Denied apps list   | Configurable in Settings                       | Not yet available               |
+| Auto-unhide toggle | Optional                                       | Always on                       |
+| Dispatch           | Dispatch-spawned sessions can use computer use | Not applicable                  |
+
+## Troubleshooting
+
+| Issue                                              | Fix                                                                                                                                                       |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "Computer use is in use by another Claude session" | Finish or exit the other session. If it crashed, the lock releases automatically when Claude detects the process is gone                                  |
+| macOS permissions prompt keeps reappearing         | Quit Claude Code completely and restart. Confirm your terminal app is listed in System Settings > Privacy & Security > Screen Recording                   |
+| `computer-use` doesn't appear in `/mcp`            | Requires macOS, Claude Code v2.1.85+, Pro or Max plan, claude.ai auth (not Bedrock/Vertex/Foundry), and an interactive session (not `-p` non-interactive) |
+
+## References
+
+- [Computer Use (CLI)](https://code.claude.com/docs/en/computer-use)
+- [Computer Use (Desktop)](https://code.claude.com/docs/en/desktop#let-claude-use-your-computer)
+- [Claude in Chrome](https://code.claude.com/docs/en/chrome)
+- [MCP Servers](https://code.claude.com/docs/en/mcp)
+- [Sandboxing](https://code.claude.com/docs/en/sandboxing)
+- [Computer Use Safety Guide](https://support.claude.com/en/articles/14128542)

--- a/features/ultraplan.md
+++ b/features/ultraplan.md
@@ -1,0 +1,90 @@
+# Claude Code Ultraplan
+
+> **Status**: Research preview. Requires a Claude Code on the web account and a GitHub repository.
+
+Start a plan from your local CLI, draft and review it on Claude Code on the web in plan mode, then execute it in the cloud or send it back to your terminal.
+
+## Why Ultraplan
+
+Ultraplan is useful when the terminal isn't enough for plan review:
+
+- **Targeted feedback**: comment on individual sections of the plan instead of replying to the whole thing
+- **Hands-off drafting**: the plan generates remotely while your terminal stays free for other work
+- **Flexible execution**: approve the plan to run on the web and open a PR, or send it back to your terminal
+
+## Requirements
+
+- Claude Code on the web account
+- GitHub repository
+- The cloud session runs in your account's default cloud environment
+
+## Launch Ultraplan
+
+Three ways to start from your local CLI session:
+
+| Method          | How                                                                                               |
+| --------------- | ------------------------------------------------------------------------------------------------- |
+| Command         | Run `/ultraplan` followed by your prompt                                                          |
+| Keyword         | Include the word `ultraplan` anywhere in a normal prompt                                          |
+| From local plan | When Claude finishes a local plan, choose **No, refine with Ultraplan on Claude Code on the web** |
+
+Example:
+
+```text
+/ultraplan migrate the auth service from sessions to JWTs
+```
+
+The command and keyword paths show a confirmation dialog before launching. The local plan path skips this since the selection already serves as confirmation.
+
+If Remote Control is active, it disconnects when ultraplan starts (both features use the claude.ai/code interface and only one can be connected at a time).
+
+## Status Indicators
+
+After launch, your CLI prompt shows a status indicator while the remote session works:
+
+| Status                       | Meaning                                                            |
+| ---------------------------- | ------------------------------------------------------------------ |
+| `ultraplan`                  | Claude is researching your codebase and drafting the plan          |
+| `ultraplan needs your input` | Claude has a clarifying question; open the session link to respond |
+| `ultraplan ready`            | The plan is ready to review in your browser                        |
+
+Run `/tasks` and select the ultraplan entry to open a detail view with the session link, agent activity, and a **Stop ultraplan** action. Stopping archives the cloud session and clears the indicator.
+
+## Review and Revise
+
+When the status changes to ready, open the session link to view the plan on claude.ai:
+
+- **Inline comments**: highlight any passage and leave a comment for Claude to address
+- **Emoji reactions**: react to a section to signal approval or concern without a full comment
+- **Outline sidebar**: jump between sections of the plan
+
+Ask Claude to address your comments and it revises the plan. Iterate as many times as needed before choosing where to execute.
+
+## Choose Where to Execute
+
+When the plan looks right, choose from the browser:
+
+### Execute on the Web
+
+Select **Approve Claude's plan and start coding** in your browser. Claude implements the plan in the same cloud session. Your terminal shows a confirmation, the status indicator clears, and work continues in the cloud. When finished, review the diff and create a PR from the web interface.
+
+### Send Back to Terminal
+
+Select **Approve plan and teleport back to terminal**. This option appears when the session was launched from your CLI and the terminal is still polling. The web session is archived so it doesn't continue in parallel.
+
+Your terminal shows the plan in a dialog titled **Ultraplan approved** with three options:
+
+| Option                | Behavior                                                                 |
+| --------------------- | ------------------------------------------------------------------------ |
+| **Implement here**    | Inject the plan into your current conversation and continue              |
+| **Start new session** | Clear current conversation and begin fresh with only the plan as context |
+| **Cancel**            | Save the plan to a file without executing; Claude prints the file path   |
+
+If you start a new session, Claude prints a `claude --resume` command so you can return to your previous conversation later.
+
+## References
+
+- [Ultraplan](https://code.claude.com/docs/en/ultraplan)
+- [Claude Code on the Web](https://code.claude.com/docs/en/claude-code-on-the-web)
+- [Plan Mode](https://code.claude.com/docs/en/permission-modes#analyze-before-you-edit-with-plan-mode)
+- [Remote Control](https://code.claude.com/docs/en/remote-control)


### PR DESCRIPTION
## Summary

- Add `features/computer-use.md`: CLI computer use on macOS (research preview), covering enabling via `/mcp`, per-app approval, safety guardrails, example workflows, and CLI vs Desktop differences
- Add `features/ultraplan.md`: cloud-based planning workflow from CLI to claude.ai/code, covering launch methods, status indicators, browser review/revision, and execution options (web or terminal)
- Update `CLAUDE.md` structure listing

Closes #41, closes #43