### PR TITLE
feat: add channels and Slack integration documentation

### DIFF
--- a/features/channels.md
+++ b/features/channels.md
@@ -1,0 +1,309 @@
+# Claude Code Channels
+
+Channels push events from external systems into a running Claude Code session so Claude can react to things happening outside the terminal. They are MCP servers that deliver messages, alerts, and webhooks while the session is open.
+
+## Overview
+
+A channel is an MCP server that pushes events into your running Claude Code session. Channels can be one-way (alerts, webhooks) or two-way (chat bridges where Claude replies back through the same channel). Events only arrive while the session is open; for always-on use, run Claude in a background process or persistent terminal.
+
+**Requirements:**
+
+- Claude Code v2.1.80 or later
+- claude.ai login (Console and API key auth not supported)
+- [Bun](https://bun.sh) runtime (for pre-built plugins)
+- Team/Enterprise: admin must enable channels
+
+**Status:** Research preview. The `--channels` flag syntax and protocol may change.
+
+## Supported Channels
+
+| Channel      | Type    | Setup                               | Token Required |
+| ------------ | ------- | ----------------------------------- | -------------- |
+| **Telegram** | Two-way | Create bot via BotFather            | Yes            |
+| **Discord**  | Two-way | Create bot in Developer Portal      | Yes            |
+| **iMessage** | Two-way | macOS only, reads Messages directly | No             |
+| **Fakechat** | Two-way | Localhost demo UI on port 8787      | No             |
+
+### Installing a Channel Plugin
+
+All channels are installed as plugins from the official marketplace:
+
+```bash
+# Install the plugin
+/plugin install telegram@claude-plugins-official
+
+# If not found, refresh marketplace first
+/plugin marketplace update claude-plugins-official
+
+# Activate after install
+/reload-plugins
+```
+
+### Configuring Credentials
+
+Telegram and Discord require bot tokens:
+
+```bash
+# Telegram
+/telegram:configure <token>
+
+# Discord
+/discord:configure <token>
+```
+
+Tokens are saved to `~/.claude/channels/<platform>/.env`. You can also set `TELEGRAM_BOT_TOKEN` or `DISCORD_BOT_TOKEN` in your shell environment.
+
+### Starting with Channels Enabled
+
+Exit Claude Code and restart with the `--channels` flag:
+
+```bash
+# Single channel
+claude --channels plugin:telegram@claude-plugins-official
+
+# Multiple channels (space-separated)
+claude --channels plugin:telegram@claude-plugins-official plugin:discord@claude-plugins-official
+```
+
+### Pairing (Telegram and Discord)
+
+1. Send any message to your bot on the platform
+1. The bot replies with a pairing code
+1. In Claude Code, approve the code:
+
+```bash
+/telegram:access pair <code>
+/discord:access pair <code>
+```
+
+4. Lock down access to your account only:
+
+```bash
+/telegram:access policy allowlist
+/discord:access policy allowlist
+```
+
+### iMessage Setup
+
+iMessage requires macOS and reads your Messages database directly:
+
+1. Grant Full Disk Access to your terminal (System Settings > Privacy & Security > Full Disk Access)
+1. Install: `/plugin install imessage@claude-plugins-official`
+1. Start: `claude --channels plugin:imessage@claude-plugins-official`
+1. Text yourself to test (self-chat bypasses access control)
+1. Allow other senders: `/imessage:access allow +15551234567`
+
+## Quickstart: Fakechat Demo
+
+Fakechat runs a chat UI on localhost with no authentication required:
+
+```bash
+# Install
+/plugin install fakechat@claude-plugins-official
+
+# Start (exit and restart)
+claude --channels plugin:fakechat@claude-plugins-official
+
+# Open http://localhost:8787 and type a message
+```
+
+Messages arrive in your session as `<channel source="fakechat">` events. Claude reads them, does the work, and replies through the chat UI.
+
+## Security
+
+### Sender Allowlists
+
+Every channel plugin maintains a sender allowlist. Only IDs you have added can push messages; everyone else is silently dropped.
+
+- **Telegram/Discord**: Bootstrap via pairing flow
+- **iMessage**: Self-chat is automatic; add others by handle
+
+### Access Controls
+
+- Being in `.mcp.json` alone is not enough to push messages; a server must also be named in `--channels`
+- The allowlist also gates permission relay (anyone who can reply can approve/deny tool use)
+- Only allowlist senders you trust
+
+## Permission Relay
+
+Two-way channels can relay permission prompts to your phone or another device. When Claude needs tool approval, the prompt appears both in your terminal and through the channel. The first answer (from either location) is applied.
+
+**Requirements:** Claude Code v2.1.81+, channel must declare `claude/channel/permission` capability.
+
+Permission relay covers tool-use approvals (`Bash`, `Write`, `Edit`). Project trust and MCP server consent dialogs only appear in the local terminal.
+
+## Building Custom Channels
+
+A custom channel needs to:
+
+1. Declare the `claude/channel` capability
+1. Emit `notifications/claude/channel` events
+1. Connect over stdio transport
+
+### Minimal Webhook Receiver (TypeScript/Bun)
+
+```typescript
+#!/usr/bin/env bun
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+const mcp = new Server(
+  { name: "webhook", version: "0.0.1" },
+  {
+    capabilities: { experimental: { "claude/channel": {} } },
+    instructions:
+      'Events from the webhook channel arrive as <channel source="webhook">. Read and act, no reply expected.',
+  }
+);
+
+await mcp.connect(new StdioServerTransport());
+
+Bun.serve({
+  port: 8788,
+  hostname: "127.0.0.1",
+  async fetch(req) {
+    const body = await req.text();
+    await mcp.notification({
+      method: "notifications/claude/channel",
+      params: {
+        content: body,
+        meta: { path: new URL(req.url).pathname, method: req.method },
+      },
+    });
+    return new Response("ok");
+  },
+});
+```
+
+Register in `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "webhook": { "command": "bun", "args": ["./webhook.ts"] }
+  }
+}
+```
+
+Test with the development flag:
+
+```bash
+claude --dangerously-load-development-channels server:webhook
+
+# In another terminal:
+curl -X POST localhost:8788 -d "build failed on main"
+```
+
+### Notification Format
+
+| Field     | Type                     | Description                                                         |
+| --------- | ------------------------ | ------------------------------------------------------------------- |
+| `content` | `string`                 | Event body (becomes `<channel>` tag body)                           |
+| `meta`    | `Record<string, string>` | Attributes on the `<channel>` tag (letters/digits/underscores only) |
+
+### Adding a Reply Tool
+
+For two-way channels, add `tools: {}` to capabilities and register tool handlers:
+
+```typescript
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: "reply",
+      description: "Send a message back over this channel",
+      inputSchema: {
+        type: "object",
+        properties: {
+          chat_id: { type: "string" },
+          text: { type: "string" },
+        },
+        required: ["chat_id", "text"],
+      },
+    },
+  ],
+}));
+
+mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
+  if (req.params.name === "reply") {
+    const { chat_id, text } = req.params.arguments as {
+      chat_id: string;
+      text: string;
+    };
+    // Send to your platform here
+    return { content: [{ type: "text", text: "sent" }] };
+  }
+  throw new Error(`unknown tool: ${req.params.name}`);
+});
+```
+
+### Server Options
+
+| Field                                                    | Type     | Required | Description                                                         |
+| -------------------------------------------------------- | -------- | -------- | ------------------------------------------------------------------- |
+| `capabilities.experimental['claude/channel']`            | `object` | Yes      | Always `{}`. Registers notification listener                        |
+| `capabilities.experimental['claude/channel/permission']` | `object` | No       | Always `{}`. Opts in to permission relay                            |
+| `capabilities.tools`                                     | `object` | No       | Two-way only. Enables tool discovery                                |
+| `instructions`                                           | `string` | No       | Added to Claude's system prompt. Describe events and reply behavior |
+
+### Testing During Research Preview
+
+Custom channels are not on the approved allowlist. Use the development flag:
+
+```bash
+# Plugin you're developing
+claude --dangerously-load-development-channels plugin:yourplugin@yourmarketplace
+
+# Bare .mcp.json server
+claude --dangerously-load-development-channels server:webhook
+```
+
+The bypass is per-entry. The `channelsEnabled` org policy still applies.
+
+## Enterprise Controls
+
+| Setting                 | Purpose                                                   | Default                        |
+| ----------------------- | --------------------------------------------------------- | ------------------------------ |
+| `channelsEnabled`       | Master switch. Must be `true` for any channel to deliver  | Channels blocked               |
+| `allowedChannelPlugins` | Which plugins can register (replaces Anthropic allowlist) | Anthropic default list applies |
+
+Pro and Max users without an organization skip these checks.
+
+### Enable for Your Organization
+
+Enable from [claude.ai > Admin settings > Claude Code > Channels](https://claude.ai/admin-settings/claude-code), or set `channelsEnabled: true` in managed settings.
+
+### Restrict Allowed Plugins
+
+```json
+{
+  "channelsEnabled": true,
+  "allowedChannelPlugins": [
+    { "marketplace": "claude-plugins-official", "plugin": "telegram" },
+    { "marketplace": "claude-plugins-official", "plugin": "discord" },
+    { "marketplace": "acme-corp-plugins", "plugin": "internal-alerts" }
+  ]
+}
+```
+
+When set, this replaces the Anthropic allowlist entirely. An empty array blocks all allowlisted plugins but `--dangerously-load-development-channels` can still bypass it.
+
+## How Channels Compare
+
+| Feature                | What It Does                                           | Good For                                          |
+| ---------------------- | ------------------------------------------------------ | ------------------------------------------------- |
+| **Claude Code on web** | Fresh cloud sandbox cloned from GitHub                 | Delegating self-contained async work              |
+| **Claude in Slack**    | Spawns web session from `@Claude` mention              | Starting tasks from team conversation context     |
+| **Standard MCP**       | Claude queries on demand; nothing pushed               | Giving Claude read/query access to a system       |
+| **Remote Control**     | Drive local session from claude.ai or mobile app       | Steering in-progress session while away from desk |
+| **Channels**           | Push events from external systems into running session | Chat bridges, CI webhooks, monitoring alerts      |
+
+## References
+
+- [Channels Documentation](https://code.claude.com/docs/en/channels)
+- [Channels Reference (Building Custom)](https://code.claude.com/docs/en/channels-reference)
+- [Official Channel Plugins](https://github.com/anthropics/claude-plugins-official/tree/main/external_plugins)

--- a/features/slack-integration.md
+++ b/features/slack-integration.md
@@ -1,0 +1,152 @@
+# Claude Code in Slack
+
+Delegate coding tasks directly from your Slack workspace. When you mention `@Claude` with a coding task, Claude detects the intent and creates a Claude Code session on the web.
+
+## Overview
+
+Claude Code in Slack is built on the Claude for Slack app but adds intelligent routing to Claude Code on the web for coding-related requests. Instead of responding as a chat assistant, Claude creates a full coding session that can read files, run commands, and create pull requests.
+
+**Prerequisites:**
+
+| Requirement            | Details                                                      |
+| ---------------------- | ------------------------------------------------------------ |
+| Claude Plan            | Pro, Max, Team, or Enterprise with Claude Code access        |
+| Claude Code on the web | Must be enabled for your account                             |
+| GitHub Account         | Connected to Claude Code on the web with authenticated repos |
+| Slack Authentication   | Slack account linked to Claude account via the Claude app    |
+
+## Setup
+
+### 1. Install the Claude App
+
+A workspace administrator installs the Claude app from the [Slack App Marketplace](https://slack.com/marketplace/A08SF47R6P4).
+
+### 2. Connect Your Claude Account
+
+1. Open the Claude app in Slack (Apps section)
+1. Navigate to the App Home tab
+1. Click "Connect" to link accounts
+1. Complete authentication in your browser
+
+### 3. Configure Claude Code on the Web
+
+- Visit [claude.ai/code](https://claude.ai/code)
+- Connect your GitHub account
+- Authenticate at least one repository
+
+### 4. Choose Routing Mode
+
+Configure in the Claude App Home in Slack:
+
+| Mode            | Behavior                                                               |
+| --------------- | ---------------------------------------------------------------------- |
+| **Code only**   | All @mentions route to Claude Code sessions                            |
+| **Code + Chat** | Claude analyzes each message and routes to Code or Chat as appropriate |
+
+In Code + Chat mode, you can click "Retry as Code" if Claude routes to Chat incorrectly (and vice versa).
+
+### 5. Add Claude to Channels
+
+Claude is not automatically added to any channels. Invite it with:
+
+```
+/invite @Claude
+```
+
+Claude only responds to @mentions in channels where it has been added. It works in both public and private channels but does not work in direct messages (DMs).
+
+## How It Works
+
+### Session Flow
+
+1. **Initiation**: @mention Claude with a coding request
+1. **Detection**: Claude analyzes intent and detects coding task
+1. **Session creation**: New Claude Code session created on claude.ai/code
+1. **Progress updates**: Status updates posted to your Slack thread
+1. **Completion**: Claude @mentions you with a summary and action buttons
+1. **Review**: Click "View Session" for the full transcript or "Create PR" for a pull request
+
+### Context Gathering
+
+- **In threads**: Claude gathers context from all messages in the thread
+- **In channels**: Claude looks at recent channel messages for context
+
+Claude may follow directions from other messages in the context. Only use Claude in trusted Slack conversations.
+
+### Message Actions
+
+| Action            | Description                                         |
+| ----------------- | --------------------------------------------------- |
+| **View Session**  | Opens full session in browser                       |
+| **Create PR**     | Creates pull request from session changes           |
+| **Retry as Code** | Re-routes a Chat response as a Claude Code task     |
+| **Change Repo**   | Select a different repository if Claude chose wrong |
+
+### Repository Selection
+
+Claude automatically selects a repository based on conversation context. If multiple repositories could apply, a dropdown lets you choose.
+
+## Access and Permissions
+
+### User-Level
+
+| Access Type       | Details                                              |
+| ----------------- | ---------------------------------------------------- |
+| Sessions          | Run under your own Claude account                    |
+| Rate Limits       | Count against your individual plan limits            |
+| Repository Access | Only repos you have personally connected             |
+| Session History   | Appear in your Claude Code history on claude.ai/code |
+
+### Workspace-Level
+
+| Control          | Description                                               |
+| ---------------- | --------------------------------------------------------- |
+| App installation | Workspace admins decide whether to install                |
+| Enterprise Grid  | Organization admins control which workspaces have access  |
+| App removal      | Removes access for all users in the workspace immediately |
+
+### Channel-Based Access Control
+
+- Claude must be explicitly invited to each channel
+- Admins can control usage by managing which channels Claude is invited to
+- Private channels provide additional visibility control
+
+## Best Practices
+
+### Writing Effective Requests
+
+- **Be specific**: Include file names, function names, or error messages
+- **Provide context**: Mention the repository if not obvious from conversation
+- **Define success**: Specify if Claude should write tests, update docs, or create a PR
+- **Use threads**: Reply in threads so Claude gathers the full discussion context
+
+### When to Use Slack vs Web
+
+| Use Slack when                               | Use the web when                                  |
+| -------------------------------------------- | ------------------------------------------------- |
+| Context already exists in a Slack discussion | You need to upload files                          |
+| Kicking off a task asynchronously            | You want real-time interaction during development |
+| Teammates need visibility into the task      | Working on longer, more complex tasks             |
+
+## Troubleshooting
+
+| Problem                   | Solution                                                                        |
+| ------------------------- | ------------------------------------------------------------------------------- |
+| Sessions not starting     | Verify account connection in App Home, check web access, ensure repos connected |
+| Repository not showing    | Connect repo at claude.ai/code, verify GitHub permissions                       |
+| Wrong repository selected | Click "Change Repo" or include repo name in your request                        |
+| Authentication errors     | Disconnect and reconnect in App Home, verify correct account                    |
+
+## Current Limitations
+
+- **GitHub only**: No support for GitLab, Bitbucket, or other providers
+- **One PR at a time**: Each session creates one pull request
+- **Rate limits apply**: Sessions use your individual plan limits
+- **Web access required**: Users without Claude Code on the web get standard chat responses
+- **Channels only**: Does not work in direct messages (DMs)
+
+## References
+
+- [Claude Code in Slack Documentation](https://code.claude.com/docs/en/slack)
+- [Claude Code on the Web](https://code.claude.com/docs/en/claude-code-on-the-web)
+- [Slack App Marketplace](https://slack.com/marketplace/A08SF47R6P4)


### PR DESCRIPTION
## Summary
- Create new channels.md for event push from Telegram, Discord, iMessage, webhooks
- Create new slack-integration.md for @Claude in Slack

Closes #34
Closes #37

## Sources
- [Channels (Official Docs)](https://code.claude.com/docs/en/channels)
- [Channels Reference](https://code.claude.com/docs/en/channels-reference)
- [Slack (Official Docs)](https://code.claude.com/docs/en/slack)