### PR TITLE
fix: remove .md suffix from code.claude.com reference URLs

### DIFF
--- a/features/additional-features.md
+++ b/features/additional-features.md
@@ -55,7 +55,7 @@ claude
 - Sessions grouped by git branch in `/resume`
 - Perfect for long-running tasks
 
-[Documentation](https://code.claude.com/docs/en/common-workflows.md#run-parallel-claude-code-sessions-with-git-worktrees)
+[Documentation](https://code.claude.com/docs/en/common-workflows#run-parallel-claude-code-sessions-with-git-worktrees)
 
 ______________________________________________________________________
 
@@ -77,7 +77,7 @@ Claude Code has multimodal capabilities.
 - Extract data from diagrams
 - Interpret visual documentation
 
-[Documentation](https://code.claude.com/docs/en/common-workflows.md#work-with-images)
+[Documentation](https://code.claude.com/docs/en/common-workflows#work-with-images)
 
 ______________________________________________________________________
 
@@ -127,7 +127,7 @@ claude --permission-mode plan -p "Your prompt"
 - Sensitive projects
 - Learning new codebases
 
-[Documentation](https://code.claude.com/docs/en/common-workflows.md#use-plan-mode-for-safe-code-analysis)
+[Documentation](https://code.claude.com/docs/en/common-workflows#use-plan-mode-for-safe-code-analysis)
 
 ______________________________________________________________________
 
@@ -154,7 +154,7 @@ claude --continue                 # Resume most recent
 | `A` | Toggle current dir vs all projects |
 | `/` | Search/filter sessions             |
 
-[Documentation](https://code.claude.com/docs/en/common-workflows.md#resume-previous-conversations)
+[Documentation](https://code.claude.com/docs/en/common-workflows#resume-previous-conversations)
 
 ______________________________________________________________________
 
@@ -184,7 +184,7 @@ Tracks: sessions, tokens, commits, PRs, cost per model.
 - Reduce MCP server overhead
 - Move CLAUDE.md details to skills
 
-[Documentation](https://code.claude.com/docs/en/costs.md)
+[Documentation](https://code.claude.com/docs/en/costs)
 
 ______________________________________________________________________
 
@@ -266,7 +266,7 @@ claude --chrome
 - Test local web applications
 - Record demo GIFs
 
-[Documentation](https://code.claude.com/docs/en/chrome.md)
+[Documentation](https://code.claude.com/docs/en/chrome)
 
 ______________________________________________________________________
 
@@ -281,7 +281,7 @@ Mention `@Claude` in Slack threads.
 - Returns pull requests in thread
 - Bug report → PR workflow
 
-[Documentation](https://code.claude.com/docs/en/slack.md)
+[Documentation](https://code.claude.com/docs/en/slack)
 
 ______________________________________________________________________
 
@@ -296,7 +296,7 @@ Native desktop app with GUI.
 - Launch local or cloud sessions
 - Browser control integration
 
-[Documentation](https://code.claude.com/docs/en/desktop.md)
+[Documentation](https://code.claude.com/docs/en/desktop)
 
 ______________________________________________________________________
 
@@ -317,7 +317,7 @@ claude --remote "Fix the login bug"  # Create web session
 claude --teleport                    # Resume web session locally
 ```
 
-[Documentation](https://code.claude.com/docs/en/devcontainer.md)
+[Documentation](https://code.claude.com/docs/en/devcontainer)
 
 ______________________________________________________________________
 
@@ -376,8 +376,8 @@ Enable with `/vim` or configure via `/config`.
 
 ## References
 
-- [Common Workflows](https://code.claude.com/docs/en/common-workflows.md)
-- [Interactive Mode](https://code.claude.com/docs/en/interactive-mode.md)
-- [GitHub Actions](https://code.claude.com/docs/en/github-actions.md)
-- [Chrome Integration](https://code.claude.com/docs/en/chrome.md)
-- [Desktop Preview](https://code.claude.com/docs/en/desktop.md)
+- [Common Workflows](https://code.claude.com/docs/en/common-workflows)
+- [Interactive Mode](https://code.claude.com/docs/en/interactive-mode)
+- [GitHub Actions](https://code.claude.com/docs/en/github-actions)
+- [Chrome Integration](https://code.claude.com/docs/en/chrome)
+- [Desktop Preview](https://code.claude.com/docs/en/desktop)

--- a/features/agents.md
+++ b/features/agents.md
@@ -417,6 +417,6 @@ claude -p "Analyze project" --max-budget-usd 5.00
 
 ## References
 
-- [Subagents Documentation](https://code.claude.com/docs/en/sub-agents.md)
-- [Common Workflows](https://code.claude.com/docs/en/common-workflows.md)
-- [Best Practices](https://code.claude.com/docs/en/best-practices.md)
+- [Subagents Documentation](https://code.claude.com/docs/en/sub-agents)
+- [Common Workflows](https://code.claude.com/docs/en/common-workflows)
+- [Best Practices](https://code.claude.com/docs/en/best-practices)

--- a/features/headless-sdk.md
+++ b/features/headless-sdk.md
@@ -372,8 +372,8 @@ claude -p "Generate a security audit report" \
 
 ## References
 
-- [Claude Code Headless Docs](https://code.claude.com/docs/en/headless.md)
-- [CLI Reference](https://code.claude.com/docs/en/cli-reference.md)
+- [Claude Code Headless Docs](https://code.claude.com/docs/en/headless)
+- [CLI Reference](https://code.claude.com/docs/en/cli-reference)
 - [Agent SDK Overview](https://platform.claude.com/docs/en/agent-sdk/overview)
 - [Agent SDK Quickstart](https://platform.claude.com/docs/en/agent-sdk/quickstart)
-- [GitHub Actions Integration](https://code.claude.com/docs/en/github-actions.md)
+- [GitHub Actions Integration](https://code.claude.com/docs/en/github-actions)

--- a/features/hooks.md
+++ b/features/hooks.md
@@ -476,5 +476,5 @@ sys.exit(0)
 
 ## References
 
-- [Official Hooks Documentation](https://code.claude.com/docs/en/hooks.md)
-- [Hooks Get Started Guide](https://code.claude.com/docs/en/hooks-guide.md)
+- [Official Hooks Documentation](https://code.claude.com/docs/en/hooks)
+- [Hooks Get Started Guide](https://code.claude.com/docs/en/hooks-guide)

--- a/features/mcp-servers.md
+++ b/features/mcp-servers.md
@@ -401,6 +401,6 @@ Denylist takes absolute precedence over allowlist. Both options can be combined.
 
 ## References
 
-- [Claude Code MCP Documentation](https://code.claude.com/docs/en/mcp.md)
+- [Claude Code MCP Documentation](https://code.claude.com/docs/en/mcp)
 - [Model Context Protocol Official Site](https://modelcontextprotocol.io/)
 - [MCP Server Development Guide](https://modelcontextprotocol.io/docs/develop/build-server)

--- a/features/memory-context.md
+++ b/features/memory-context.md
@@ -445,6 +445,6 @@ Official Anthropic guidance and community best practices for CLAUDE.md formattin
 
 ## References
 
-- [Memory Management](https://code.claude.com/docs/en/memory.md)
-- [Best Practices](https://code.claude.com/docs/en/best-practices.md)
-- [Context Management](https://code.claude.com/docs/en/interactive-mode.md)
+- [Memory Management](https://code.claude.com/docs/en/memory)
+- [Best Practices](https://code.claude.com/docs/en/best-practices)
+- [Context Management](https://code.claude.com/docs/en/interactive-mode)

--- a/features/plugins.md
+++ b/features/plugins.md
@@ -445,6 +445,6 @@ claude --debug --plugin-dir ./my-plugin
 
 ## References
 
-- [Plugins Documentation](https://code.claude.com/docs/en/plugins.md)
-- [Creating Plugins](https://code.claude.com/docs/en/creating-plugins.md)
-- [Plugin Marketplaces](https://code.claude.com/docs/en/plugin-marketplaces.md)
+- [Plugins Documentation](https://code.claude.com/docs/en/plugins)
+- [Plugins Reference](https://code.claude.com/docs/en/plugins-reference)
+- [Plugin Marketplaces](https://code.claude.com/docs/en/plugin-marketplaces)

--- a/features/remote-control.md
+++ b/features/remote-control.md
@@ -69,4 +69,4 @@ Remote Control is **off by default** for Team and Enterprise plans. An organizat
 
 ## References
 
-- [Remote Control Docs](https://code.claude.com/docs/en/remote-control.md)
+- [Remote Control Docs](https://code.claude.com/docs/en/remote-control)

--- a/features/rules.md
+++ b/features/rules.md
@@ -455,5 +455,5 @@ ______________________________________________________________________
 
 ## References
 
-- [Claude Code Memory Documentation](https://code.claude.com/docs/en/memory.md)
+- [Claude Code Memory Documentation](https://code.claude.com/docs/en/memory)
 - [Memory & Context Guide](./memory-context.md)

--- a/features/settings.md
+++ b/features/settings.md
@@ -360,6 +360,6 @@ claude --model opus
 
 ## References
 
-- [Settings Documentation](https://code.claude.com/docs/en/settings.md)
-- [IAM & Permissions](https://code.claude.com/docs/en/iam.md)
-- [Model Configuration](https://code.claude.com/docs/en/model-config.md)
+- [Settings Documentation](https://code.claude.com/docs/en/settings)
+- [IAM & Permissions](https://code.claude.com/docs/en/iam)
+- [Model Configuration](https://code.claude.com/docs/en/model-config)

--- a/features/skills.md
+++ b/features/skills.md
@@ -322,6 +322,6 @@ agent: Explore
 
 ## References
 
-- [Skills Documentation](https://code.claude.com/docs/en/skills.md)
-- [Interactive Mode Reference](https://code.claude.com/docs/en/interactive-mode.md)
-- [CLI Reference](https://code.claude.com/docs/en/cli-reference.md)
+- [Skills Documentation](https://code.claude.com/docs/en/skills)
+- [Interactive Mode Reference](https://code.claude.com/docs/en/interactive-mode)
+- [CLI Reference](https://code.claude.com/docs/en/cli-reference)


### PR DESCRIPTION
## Summary
- Replace `.md` URLs on code.claude.com with clean HTML URLs
- 38 instances across 11 files
- `.md` URLs return raw markdown that does not render in browsers
- HTML URLs render with sidebar, search, and navigation
- Also fixed a broken `creating-plugins` URL (page does not exist) to point to the `plugins-reference` page instead

## Why
`code.claude.com/docs/en/<page>.md` returns raw markdown (meant for LLM ingestion via llms.txt). Human readers clicking reference links expect the browser-rendered HTML version at `code.claude.com/docs/en/<page>` which has navigation, search, and formatting.