### PR TITLE
chore: standardize Sources sections and format consistency

### DIFF
--- a/features/additional-features.md
+++ b/features/additional-features.md
@@ -374,7 +374,7 @@ Enable with `/vim` or configure via `/config`.
 - Text objects: `iw/aw`, `i"/a"`, `i(/a(`
 - Yank/paste: `yy`, `yw`, `p/P`
 
-## References
+## Sources
 
 - [Common Workflows](https://code.claude.com/docs/en/common-workflows)
 - [Interactive Mode](https://code.claude.com/docs/en/interactive-mode)

--- a/features/agent-teams-setup.md
+++ b/features/agent-teams-setup.md
@@ -359,3 +359,11 @@ The fix is always the same: explicitly mention `TeamCreate` and `team_name` in y
 ## Next Steps
 
 Your environment is ready. Head to [Agent Teams](agent-teams.md) for architecture details, display modes, hooks, and the full tool reference.
+
+## Sources
+
+- [Agent Teams Documentation](https://code.claude.com/docs/en/agent-teams)
+- [Ghostty Terminal](https://ghostty.org/)
+- [tmux](https://github.com/tmux/tmux/wiki)
+- [Starship Prompt](https://starship.rs/)
+- [Agent Teams](agent-teams.md) - Architecture, display modes, hooks, and tool reference

--- a/features/agent-teams.md
+++ b/features/agent-teams.md
@@ -411,7 +411,7 @@ tmux kill-session -t <session-name>
 
 > **Tip**: `CLAUDE.md` works normally with agent teams. Teammates read `CLAUDE.md` files from their working directory, so you can provide project-specific guidance to all teammates.
 
-## References
+## Sources
 
 - [Agent Teams Documentation](https://code.claude.com/docs/en/agent-teams)
 - [Building a C Compiler with a Team of Parallel Claudes](https://www.anthropic.com/engineering/building-c-compiler) - Real-world example: 16 parallel agents, 2B tokens, 100K-line compiler

--- a/features/agents.md
+++ b/features/agents.md
@@ -415,7 +415,7 @@ claude -p "Analyze project" --max-budget-usd 5.00
 - Can resume after Claude Code restart
 - Cleaned up after 30 days (default)
 
-## References
+## Sources
 
 - [Subagents Documentation](https://code.claude.com/docs/en/sub-agents)
 - [Common Workflows](https://code.claude.com/docs/en/common-workflows)

--- a/features/auto-memory.md
+++ b/features/auto-memory.md
@@ -147,7 +147,7 @@ From the [Claude Code v2.1.59 changelog](https://github.com/anthropics/claude-co
 
 > Claude automatically saves useful context to auto-memory. Manage with /memory
 
-## References
+## Sources
 
 - [Memory Management (Official Docs)](https://docs.anthropic.com/docs/en/memory)
 - [Claude Code Settings](https://docs.anthropic.com/docs/en/settings)

--- a/features/auto-mode.md
+++ b/features/auto-mode.md
@@ -272,7 +272,7 @@ The classifier is designed to be **orthogonal to chain-of-thought monitoring**. 
 - **FPR** (false positive rate): Percentage of safe actions incorrectly blocked
 - **FNR** (false negative rate): Percentage of unsafe actions incorrectly allowed
 
-## References
+## Sources
 
 - [Auto Mode Engineering Blog Post](https://www.anthropic.com/engineering/claude-code-auto-mode)
 - [Permission Modes](https://code.claude.com/docs/en/permission-modes)

--- a/features/channels.md
+++ b/features/channels.md
@@ -302,7 +302,7 @@ When set, this replaces the Anthropic allowlist entirely. An empty array blocks 
 | **Remote Control**     | Drive local session from claude.ai or mobile app       | Steering in-progress session while away from desk |
 | **Channels**           | Push events from external systems into running session | Chat bridges, CI webhooks, monitoring alerts      |
 
-## References
+## Sources
 
 - [Channels Documentation](https://code.claude.com/docs/en/channels)
 - [Channels Reference (Building Custom)](https://code.claude.com/docs/en/channels-reference)

--- a/features/checkpointing.md
+++ b/features/checkpointing.md
@@ -86,7 +86,7 @@ Checkpoints are designed for quick, session-level recovery:
 - Think of checkpoints as "local undo" and Git as "permanent history"
 - Checkpoints complement but don't replace proper version control
 
-## References
+## Sources
 
 - [Checkpointing](https://code.claude.com/docs/en/checkpointing)
 - [Interactive Mode](https://code.claude.com/docs/en/interactive-mode)

--- a/features/code-review.md
+++ b/features/code-review.md
@@ -147,7 +147,7 @@ If the check run reports findings but no inline comments appear:
 - **Files changed annotations**: Findings render as annotations on diff lines
 - **Review body**: Findings for lines that moved appear under "Additional findings" in the review body
 
-## References
+## Sources
 
 - [Code Review](https://code.claude.com/docs/en/code-review)
 - [GitHub Actions](https://code.claude.com/docs/en/github-actions)

--- a/features/computer-use.md
+++ b/features/computer-use.md
@@ -126,7 +126,7 @@ screens, and tell me if any screen takes more than a second to load.
 | macOS permissions prompt keeps reappearing         | Quit Claude Code completely and restart. Confirm your terminal app is listed in System Settings > Privacy & Security > Screen Recording                   |
 | `computer-use` doesn't appear in `/mcp`            | Requires macOS, Claude Code v2.1.85+, Pro or Max plan, claude.ai auth (not Bedrock/Vertex/Foundry), and an interactive session (not `-p` non-interactive) |
 
-## References
+## Sources
 
 - [Computer Use (CLI)](https://code.claude.com/docs/en/computer-use)
 - [Computer Use (Desktop)](https://code.claude.com/docs/en/desktop#let-claude-use-your-computer)

--- a/features/github-actions.md
+++ b/features/github-actions.md
@@ -540,7 +540,7 @@ claude-review:
     ANTHROPIC_API_KEY: $ANTHROPIC_API_KEY
 ```
 
-## References
+## Sources
 
 - [Official Docs: GitHub Actions](https://code.claude.com/docs/en/github-actions)
 - [Official Docs: Headless Mode](https://code.claude.com/docs/en/headless)

--- a/features/gitlab-cicd.md
+++ b/features/gitlab-cicd.md
@@ -170,7 +170,7 @@ Create a `CLAUDE.md` at repository root to define coding standards and conventio
 - **Bedrock**: Verify OIDC config, role impersonation, region, and model availability
 - **Vertex**: Verify WIF configuration and service account permissions
 
-## References
+## Sources
 
 - [GitLab CI/CD](https://code.claude.com/docs/en/gitlab-ci-cd)
 - [GitHub Actions](https://code.claude.com/docs/en/github-actions)

--- a/features/headless-sdk.md
+++ b/features/headless-sdk.md
@@ -370,7 +370,7 @@ claude -p "Generate a security audit report" \
 | Context persistence | `--resume session_id`        | `resume=session_id`             |
 | Custom validation   | Post-process JSON            | `hooks={"PostToolUse": [...]}`  |
 
-## References
+## Sources
 
 - [Claude Code Headless Docs](https://code.claude.com/docs/en/headless)
 - [CLI Reference](https://code.claude.com/docs/en/cli-reference)

--- a/features/hooks.md
+++ b/features/hooks.md
@@ -474,7 +474,7 @@ sys.exit(0)
 - **Enterprise policy**: Administrators can use `allowManagedHooksOnly` to block user/project hooks
 - **File watcher**: Settings file edits are normally picked up automatically; if not, restart the session
 
-## References
+## Sources
 
 - [Official Hooks Documentation](https://code.claude.com/docs/en/hooks)
 - [Hooks Get Started Guide](https://code.claude.com/docs/en/hooks-guide)

--- a/features/ide-integrations.md
+++ b/features/ide-integrations.md
@@ -427,7 +427,7 @@ Settings → Profiles → Keyboard → Check "Use Option as Meta Key"
 - Check for conflicting IDE shortcuts
 - Run `/terminal-setup`
 
-## References
+## Sources
 
 - [VS Code Integration](https://code.claude.com/docs/en/vs-code)
 - [JetBrains Integration](https://code.claude.com/docs/en/jetbrains)

--- a/features/mcp-servers.md
+++ b/features/mcp-servers.md
@@ -399,7 +399,7 @@ Allow user-configured servers within policy constraints. Entries can match by `s
 
 Denylist takes absolute precedence over allowlist. Both options can be combined.
 
-## References
+## Sources
 
 - [Claude Code MCP Documentation](https://code.claude.com/docs/en/mcp)
 - [Model Context Protocol Official Site](https://modelcontextprotocol.io/)

--- a/features/memory-context.md
+++ b/features/memory-context.md
@@ -443,7 +443,7 @@ Official Anthropic guidance and community best practices for CLAUDE.md formattin
 
 **Negative-only rules** -- a file full of "don't do X" without positive guidance wastes tokens on low-value constraints.
 
-## References
+## Sources
 
 - [Memory Management](https://code.claude.com/docs/en/memory)
 - [Best Practices](https://code.claude.com/docs/en/best-practices)

--- a/features/plugins.md
+++ b/features/plugins.md
@@ -443,7 +443,7 @@ claude --debug --plugin-dir ./my-plugin
 /plugin  # See "Errors" tab
 ```
 
-## References
+## Sources
 
 - [Plugins Documentation](https://code.claude.com/docs/en/plugins)
 - [Plugins Reference](https://code.claude.com/docs/en/plugins-reference)

--- a/features/pricing.md
+++ b/features/pricing.md
@@ -115,7 +115,7 @@ Automode requires all of the following:
 | Pay only for what you use          | **API**                                      |
 | Highest context + compliance       | **Enterprise**                               |
 
-## References
+## Sources
 
 - [Claude Pricing](https://claude.com/pricing)
 - [Using Claude Code with Pro/Max](https://support.claude.com/en/articles/11145838-using-claude-code-with-your-pro-or-max-plan)

--- a/features/remote-control.md
+++ b/features/remote-control.md
@@ -67,6 +67,6 @@ Remote Control is **off by default** for Team and Enterprise plans. An organizat
 | Network timeout         | Sessions time out after roughly 10 minutes of network unavailability                                          |
 | One remote per process  | In interactive mode each instance supports one remote connection. Use server mode with `--spawn` for multiple |
 
-## References
+## Sources
 
 - [Remote Control Docs](https://code.claude.com/docs/en/remote-control)

--- a/features/rules.md
+++ b/features/rules.md
@@ -453,7 +453,7 @@ ______________________________________________________________________
    /memory
    ```
 
-## References
+## Sources
 
 - [Claude Code Memory Documentation](https://code.claude.com/docs/en/memory)
 - [Memory & Context Guide](./memory-context.md)

--- a/features/scheduled-tasks.md
+++ b/features/scheduled-tasks.md
@@ -241,7 +241,7 @@ Day-of-week: `0` or `7` for Sunday through `6` for Saturday. Extended syntax (`L
 - 50 task limit per session
 - 7-day automatic expiry for recurring tasks
 
-## References
+## Sources
 
 - [Cloud Scheduled Tasks](https://code.claude.com/docs/en/web-scheduled-tasks)
 - [Desktop Scheduled Tasks](https://code.claude.com/docs/en/desktop-scheduled-tasks)

--- a/features/settings.md
+++ b/features/settings.md
@@ -358,7 +358,7 @@ claude --model opus
 }
 ```
 
-## References
+## Sources
 
 - [Settings Documentation](https://code.claude.com/docs/en/settings)
 - [IAM & Permissions](https://code.claude.com/docs/en/iam)

--- a/features/skills.md
+++ b/features/skills.md
@@ -320,7 +320,7 @@ agent: Explore
 3. Generate findings report
 ```
 
-## References
+## Sources
 
 - [Skills Documentation](https://code.claude.com/docs/en/skills)
 - [Interactive Mode Reference](https://code.claude.com/docs/en/interactive-mode)

--- a/features/slack-integration.md
+++ b/features/slack-integration.md
@@ -145,7 +145,7 @@ Claude automatically selects a repository based on conversation context. If mult
 - **Web access required**: Users without Claude Code on the web get standard chat responses
 - **Channels only**: Does not work in direct messages (DMs)
 
-## References
+## Sources
 
 - [Claude Code in Slack Documentation](https://code.claude.com/docs/en/slack)
 - [Claude Code on the Web](https://code.claude.com/docs/en/claude-code-on-the-web)

--- a/features/testing.md
+++ b/features/testing.md
@@ -820,7 +820,7 @@ When updating configuration formats:
 
 ______________________________________________________________________
 
-## See Also
+## Sources
 
 - [Settings](./settings.md) - Configuration options being validated
 - [Skills](./skills.md) - Skill format and frontmatter

--- a/features/ultraplan.md
+++ b/features/ultraplan.md
@@ -82,7 +82,7 @@ Your terminal shows the plan in a dialog titled **Ultraplan approved** with thre
 
 If you start a new session, Claude prints a `claude --resume` command so you can return to your previous conversation later.
 
-## References
+## Sources
 
 - [Ultraplan](https://code.claude.com/docs/en/ultraplan)
 - [Claude Code on the Web](https://code.claude.com/docs/en/claude-code-on-the-web)

--- a/features/voice-dictation.md
+++ b/features/voice-dictation.md
@@ -101,7 +101,7 @@ Supports BCP 47 codes or language names. If the language isn't supported, dictat
 | Nothing happens when holding Space        | Ensure voice is enabled (`/voice`). Check terminal sends key-repeat events   |
 | Transcription garbled or wrong language   | Set correct language in `/config`                                            |
 
-## References
+## Sources
 
 - [Voice Dictation](https://code.claude.com/docs/en/voice-dictation)
 - [Keyboard Shortcuts](https://code.claude.com/docs/en/keybindings)


### PR DESCRIPTION
## Summary
- Standardize bottom reference sections to `## Sources` across all feature docs
- Validate all internal cross-references
- Run mdformat across features/ and README.md for consistency

## Why
Drift accumulated over many small PRs. This consolidates the final state for a consistent reader experience.