### PR TITLE
feat: add how-claude-code-works and claude-directory foundational docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,41 +4,73 @@ Comprehensive documentation of Claude Code's extensibility features and capabili
 
 ## Quick Navigation
 
-| Feature                                                  | Description            | Use When                                                    |
-| -------------------------------------------------------- | ---------------------- | ----------------------------------------------------------- |
-| [Tools](./features/tools.md)                             | Built-in tools         | Understand Read, Write, Edit, Bash, Grep, and more          |
-| [Hooks](./features/hooks.md)                             | Lifecycle automation   | Validate, format, protect files automatically               |
-| [MCP Servers](./features/mcp-servers.md)                 | External integrations  | Connect to databases, APIs, third-party tools               |
-| [Agents](./features/agents.md)                           | Specialized subagents  | Delegate complex tasks, isolate context                     |
-| [Agent Teams](./features/agent-teams.md)                 | Multi-agent sessions   | Coordinate parallel work across independent instances       |
-| [Skills](./features/skills.md)                           | Custom slash commands  | Create reusable commands and workflows                      |
-| [Settings](./features/settings.md)                       | Configuration options  | Customize behavior, permissions, API                        |
-| [IDE Integrations](./features/ide-integrations.md)       | Editor support         | VSCode, JetBrains, Vim/Neovim, Chrome                       |
-| [Memory & Context](./features/memory-context.md)         | CLAUDE.md and context  | Persistent instructions, context management                 |
-| [Auto Memory](./features/auto-memory.md)                 | MEMORY.md (automatic)  | Claude's self-maintained notes and learnings per project    |
-| [Rules](./features/rules.md)                             | Modular memory files   | Path-conditional guidelines, organized by topic             |
-| [GitHub Actions](./features/github-actions.md)           | CI/CD integration      | PR review, issue-to-PR, automated workflows                 |
-| [Remote Control](./features/remote-control.md)           | Mobile/web access      | Control terminal sessions from phone, tablet, or browser    |
-| [Headless/SDK](./features/headless-sdk.md)               | Programmatic usage     | CLI automation, custom agents, scripting                    |
-| [Plugins](./features/plugins.md)                         | Shareable packages     | Distribute tools, LSP servers, team standardization         |
-| [Auto Mode](./features/auto-mode.md)                     | Permission automation  | Reduce permission prompts with AI-powered safety checks     |
-| [Security & Sandbox](./features/security-sandbox.md)     | Isolation and controls | Secure execution, network isolation, enterprise policies    |
-| [Testing](./features/testing.md)                         | Config validation      | Validate settings, skills, schemas in CI/CD                 |
-| [Plans & Pricing](./features/pricing.md)                 | Plan comparison        | Pricing, Claude Code access, feature matrix by plan         |
-| [Scheduled Tasks](./features/scheduled-tasks.md)         | Recurring automation   | Cloud cron jobs, desktop tasks, CLI loops                   |
-| [Checkpointing](./features/checkpointing.md)             | Session recovery       | Undo changes, rewind to previous states, explore safely     |
-| [Code Review](./features/code-review.md)                 | Automated PR review    | Multi-agent analysis for bugs, security, regressions        |
-| [Channels](./features/channels.md)                       | Persistent AI threads  | Long-running projects, recurring workflows, team context    |
-| [Slack Integration](./features/slack-integration.md)     | Slack-based control    | Chat with Claude in Slack, trigger tasks from channels      |
-| [GitLab CI/CD](./features/gitlab-cicd.md)                | GitLab pipelines       | MR automation, @claude mentions, Bedrock/Vertex auth        |
-| [Voice Dictation](./features/voice-dictation.md)         | Speech input           | Speak prompts instead of typing, coding vocabulary          |
-| [Computer Use](./features/computer-use.md)               | GUI automation         | Native app testing, visual debugging, simulator control     |
-| [Ultraplan](./features/ultraplan.md)                     | Cloud planning         | Draft plans on the web, review in browser, execute anywhere |
-| [Additional Features](./features/additional-features.md) | Advanced capabilities  | Git worktrees, images, sessions, plan mode                  |
+| Feature                                                      | Description            | Use When                                                    |
+| ------------------------------------------------------------ | ---------------------- | ----------------------------------------------------------- |
+| [How Claude Code Works](./features/how-claude-code-works.md) | Core architecture      | Understand the agentic loop, sessions, and what Claude sees |
+| [`.claude` Directory](./features/claude-directory.md)        | Config file reference  | Learn what lives in `.claude/` and `~/.claude/`             |
+| [Tools](./features/tools.md)                                 | Built-in tools         | Understand Read, Write, Edit, Bash, Grep, and more          |
+| [Hooks](./features/hooks.md)                                 | Lifecycle automation   | Validate, format, protect files automatically               |
+| [MCP Servers](./features/mcp-servers.md)                     | External integrations  | Connect to databases, APIs, third-party tools               |
+| [Agents](./features/agents.md)                               | Specialized subagents  | Delegate complex tasks, isolate context                     |
+| [Agent Teams](./features/agent-teams.md)                     | Multi-agent sessions   | Coordinate parallel work across independent instances       |
+| [Skills](./features/skills.md)                               | Custom slash commands  | Create reusable commands and workflows                      |
+| [Settings](./features/settings.md)                           | Configuration options  | Customize behavior, permissions, API                        |
+| [IDE Integrations](./features/ide-integrations.md)           | Editor support         | VSCode, JetBrains, Vim/Neovim, Chrome                       |
+| [Memory & Context](./features/memory-context.md)             | CLAUDE.md and context  | Persistent instructions, context management                 |
+| [Auto Memory](./features/auto-memory.md)                     | MEMORY.md (automatic)  | Claude's self-maintained notes and learnings per project    |
+| [Rules](./features/rules.md)                                 | Modular memory files   | Path-conditional guidelines, organized by topic             |
+| [GitHub Actions](./features/github-actions.md)               | CI/CD integration      | PR review, issue-to-PR, automated workflows                 |
+| [Remote Control](./features/remote-control.md)               | Mobile/web access      | Control terminal sessions from phone, tablet, or browser    |
+| [Headless/SDK](./features/headless-sdk.md)                   | Programmatic usage     | CLI automation, custom agents, scripting                    |
+| [Plugins](./features/plugins.md)                             | Shareable packages     | Distribute tools, LSP servers, team standardization         |
+| [Auto Mode](./features/auto-mode.md)                         | Permission automation  | Reduce permission prompts with AI-powered safety checks     |
+| [Security & Sandbox](./features/security-sandbox.md)         | Isolation and controls | Secure execution, network isolation, enterprise policies    |
+| [Testing](./features/testing.md)                             | Config validation      | Validate settings, skills, schemas in CI/CD                 |
+| [Plans & Pricing](./features/pricing.md)                     | Plan comparison        | Pricing, Claude Code access, feature matrix by plan         |
+| [Scheduled Tasks](./features/scheduled-tasks.md)             | Recurring automation   | Cloud cron jobs, desktop tasks, CLI loops                   |
+| [Checkpointing](./features/checkpointing.md)                 | Session recovery       | Undo changes, rewind to previous states, explore safely     |
+| [Code Review](./features/code-review.md)                     | Automated PR review    | Multi-agent analysis for bugs, security, regressions        |
+| [Channels](./features/channels.md)                           | Persistent AI threads  | Long-running projects, recurring workflows, team context    |
+| [Slack Integration](./features/slack-integration.md)         | Slack-based control    | Chat with Claude in Slack, trigger tasks from channels      |
+| [GitLab CI/CD](./features/gitlab-cicd.md)                    | GitLab pipelines       | MR automation, @claude mentions, Bedrock/Vertex auth        |
+| [Voice Dictation](./features/voice-dictation.md)             | Speech input           | Speak prompts instead of typing, coding vocabulary          |
+| [Computer Use](./features/computer-use.md)                   | GUI automation         | Native app testing, visual debugging, simulator control     |
+| [Ultraplan](./features/ultraplan.md)                         | Cloud planning         | Draft plans on the web, review in browser, execute anywhere |
+| [Additional Features](./features/additional-features.md)     | Advanced capabilities  | Git worktrees, images, sessions, plan mode                  |
 
 ______________________________________________________________________
 
 ## Feature Summaries
+
+### How Claude Code Works
+
+**Purpose**: Understand the core architecture before diving into individual features.
+
+**Key Concepts**:
+
+- The agentic loop: prompt → gather context → take action → verify → repeat
+- Tools as the primitives that turn a language model into an agent
+- Sessions, context windows, and checkpoints
+- Resume vs fork for session continuity
+
+[Full Documentation →](./features/how-claude-code-works.md)
+
+______________________________________________________________________
+
+### The `.claude` Directory
+
+**Purpose**: Reference for every file Claude Code reads from your project and home directory.
+
+**Key Concepts**:
+
+- Project scope (`.claude/`) vs user scope (`~/.claude/`) vs managed scope
+- Settings precedence order (managed > CLI flags > local > project > user)
+- Subdirectories: `rules/`, `skills/`, `commands/`, `agents/`, `agent-memory/`, `output-styles/`
+- How to inspect what actually loaded: `/context`, `/memory`, `/hooks`, `/doctor`
+
+[Full Documentation →](./features/claude-directory.md)
+
+______________________________________________________________________
 
 ### Hooks
 

--- a/features/claude-directory.md
+++ b/features/claude-directory.md
@@ -1,0 +1,261 @@
+# The `.claude` Directory
+
+Claude Code reads instructions, settings, skills, subagents, and memory from two locations:
+
+- **`.claude/`** inside your project (shared with your team via git)
+- **`~/.claude/`** in your home directory (personal configuration, applies across all projects)
+
+Most users only edit `CLAUDE.md` and `settings.json`. Everything else is optional: add skills, rules, or subagents as you need them.
+
+## Scopes
+
+Claude Code has three configuration scopes, with a clear precedence order:
+
+| Scope             | Location                                                                                       | Commit to Git?   | Purpose                                               |
+| ----------------- | ---------------------------------------------------------------------------------------------- | ---------------- | ----------------------------------------------------- |
+| **Managed**       | System-level, varies by OS (`managed-settings.json`)                                           | N/A              | Enterprise-enforced policies that override everything |
+| **Project**       | `.claude/` in your repo, plus `CLAUDE.md`, `.mcp.json`, `.worktreeinclude` at the project root | Yes (most files) | Team-shared configuration, rules, and extensions      |
+| **User (Global)** | `~/.claude/`                                                                                   | No               | Your personal configuration across all projects       |
+
+**Precedence (highest first):**
+
+1. Managed settings from your organization
+1. CLI flags (`--permission-mode`, `--settings`)
+1. `.claude/settings.local.json` (your personal project overrides)
+1. `.claude/settings.json` (team-shared project settings)
+1. `~/.claude/settings.json` (your global defaults)
+
+Array settings like `permissions.allow` **combine** across all scopes. Scalar settings like `model` use the most specific value.
+
+## Project-Scope Files
+
+These live in your repository and should be committed so your team shares them.
+
+### Project Root
+
+| File               | Committed         | Purpose                                        |
+| ------------------ | ----------------- | ---------------------------------------------- |
+| `CLAUDE.md`        | Yes               | Project instructions loaded into every session |
+| `CLAUDE.local.md`  | No (gitignore it) | Your private preferences for this project      |
+| `.mcp.json`        | Yes               | Team-shared MCP servers                        |
+| `.worktreeinclude` | Yes               | Gitignored files to copy into new worktrees    |
+
+### `.claude/` Subdirectory
+
+| File / Folder                | Committed            | Purpose                                                       |
+| ---------------------------- | -------------------- | ------------------------------------------------------------- |
+| `settings.json`              | Yes                  | Permissions, hooks, statusline, model, env vars, output style |
+| `settings.local.json`        | No (auto-gitignored) | Your personal overrides for this project                      |
+| `rules/*.md`                 | Yes                  | Topic-scoped instructions, optionally path-gated              |
+| `skills/<name>/SKILL.md`     | Yes                  | Reusable prompts invoked with `/name`                         |
+| `commands/*.md`              | Yes                  | Single-file prompts (same mechanism as skills)                |
+| `output-styles/*.md`         | Yes                  | Custom system-prompt sections (if your team shares any)       |
+| `agents/*.md`                | Yes                  | Subagent definitions with their own prompt and tools          |
+| `agent-memory/<name>/`       | Yes                  | Persistent memory for subagents with `memory: project`        |
+| `agent-memory-local/<name>/` | No                   | Subagent memory with `memory: local` (gitignored)             |
+
+## User-Scope Files (`~/.claude/`)
+
+These are your personal configuration. Never committed to any repository.
+
+| File / Folder                          | Purpose                                                                                 |
+| -------------------------------------- | --------------------------------------------------------------------------------------- |
+| `~/.claude.json`                       | App state: OAuth session, UI toggles, personal MCP servers, per-project trust decisions |
+| `~/.claude/CLAUDE.md`                  | Personal preferences loaded alongside every project's `CLAUDE.md`                       |
+| `~/.claude/settings.json`              | Your default settings for all projects                                                  |
+| `~/.claude/keybindings.json`           | Custom keyboard shortcuts                                                               |
+| `~/.claude/projects/<project>/memory/` | [Auto memory](./auto-memory.md): Claude's notes to itself per project                   |
+| `~/.claude/rules/`                     | User-level rules that apply to every project                                            |
+| `~/.claude/skills/`                    | Personal skills available in every project                                              |
+| `~/.claude/commands/`                  | Personal single-file commands                                                           |
+| `~/.claude/output-styles/`             | Custom system-prompt styles                                                             |
+| `~/.claude/agents/`                    | Personal subagents available everywhere                                                 |
+| `~/.claude/agent-memory/<name>/`       | Subagent memory with `memory: user` (cross-project)                                     |
+
+## What Each Directory Does
+
+### `CLAUDE.md`
+
+Project-specific instructions that shape how Claude works in this repository. Loaded into context at the **start of every session**. Put your conventions, common commands, and architectural context here.
+
+Target under 200 lines. Longer files still load but may reduce adherence. Also works at `.claude/CLAUDE.md` if you prefer to keep the project root clean.
+
+See [Memory & Context](./memory-context.md).
+
+### `settings.json`
+
+Settings Claude Code applies directly: [permissions](./settings.md) that control which commands and tools Claude can use, [hooks](./hooks.md) that run your scripts at specific points, statusline, default model, env vars, and output style.
+
+Unlike `CLAUDE.md` (guidance Claude reads), settings are **enforced** whether Claude follows them or not.
+
+See [Settings](./settings.md).
+
+### `rules/`
+
+Project instructions split into topic files that can load conditionally based on file paths.
+
+- A rule **without** `paths:` frontmatter loads at session start (like `CLAUDE.md`)
+- A rule **with** `paths:` frontmatter loads only when Claude reads a matching file
+
+Example `.claude/rules/testing.md`:
+
+```markdown
+---
+paths:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+---
+
+# Testing Rules
+
+- Use descriptive test names: "should [expected] when [condition]"
+- Mock external dependencies, not internal modules
+- Clean up side effects in afterEach
+```
+
+See [Rules](./rules.md).
+
+### `skills/`
+
+Reusable prompts you or Claude invoke with `/skill-name`. Each skill is a folder with a `SKILL.md` file plus any supporting files it needs.
+
+Example `.claude/skills/security-review/SKILL.md`:
+
+```markdown
+---
+description: Reviews code changes for security vulnerabilities
+disable-model-invocation: true
+argument-hint: <branch-or-path>
+---
+
+## Diff to review
+
+!`git diff $ARGUMENTS`
+
+Audit the changes above for injection risks and auth gaps.
+Use checklist.md in this skill directory for the full checklist.
+```
+
+Skills can bundle reference docs, templates, scripts. See [Skills](./skills.md).
+
+### `commands/`
+
+Single-file prompts invoked with `/name`. A file at `commands/deploy.md` creates `/deploy` the same way a skill at `skills/deploy/SKILL.md` does.
+
+**Commands and skills are the same mechanism.** For new workflows, prefer `skills/` since it lets you bundle supporting files. Commands remain supported.
+
+### `agents/`
+
+Specialized [subagents](./agents.md) with their own system prompt, tool access, and optionally their own model. Each subagent runs in a **fresh context window**, keeping the main conversation clean.
+
+Example `.claude/agents/code-reviewer.md`:
+
+```markdown
+---
+name: code-reviewer
+description: Reviews code for correctness, security, and maintainability
+tools: Read, Grep, Glob
+---
+
+You are a senior code reviewer. Review for:
+
+1. Correctness: logic errors, edge cases, null handling
+2. Security: injection, auth bypass, data exposure
+3. Maintainability: naming, complexity, duplication
+```
+
+### `agent-memory/`
+
+Persistent memory for subagents. Created only for subagents with `memory: project` (or `memory: local`, `memory: user`) in their frontmatter. Each subagent has its own `MEMORY.md` it reads and writes itself.
+
+This is **distinct** from your main-session auto memory at `~/.claude/projects/`.
+
+### `output-styles/`
+
+Custom system-prompt sections that adjust how Claude works. Each markdown file defines a style. Select one via `/config` or the `outputStyle` setting. Most live globally in `~/.claude/output-styles/` since they're personal.
+
+### `~/.claude/projects/<project>/memory/` (Auto Memory)
+
+Claude's [auto memory](./auto-memory.md): learnings Claude saves automatically as you work. You don't write these files, Claude does.
+
+- `MEMORY.md` is the index loaded at session start (first 200 lines or 25 KB)
+- Topic files like `debugging.md` or `architecture.md` are read on demand
+
+See [Auto Memory](./auto-memory.md).
+
+## Example Project Structure
+
+A realistic `.claude/` for a TypeScript project:
+
+```
+your-project/
+├── CLAUDE.md                       # Team conventions, build/test commands
+├── .mcp.json                       # Shared MCP servers (e.g., GitHub)
+├── .worktreeinclude                # Copy .env into worktrees
+└── .claude/
+    ├── settings.json               # Permissions, hooks
+    ├── settings.local.json         # Your personal overrides (gitignored)
+    ├── rules/
+    │   ├── testing.md              # Scoped to **/*.test.ts
+    │   └── api-design.md           # Scoped to src/api/**/*.ts
+    ├── skills/
+    │   └── security-review/
+    │       ├── SKILL.md
+    │       └── checklist.md
+    ├── commands/
+    │   └── fix-issue.md            # /fix-issue <number>
+    ├── agents/
+    │   └── code-reviewer.md
+    └── agent-memory/
+        └── code-reviewer/
+            └── MEMORY.md           # Subagent writes this
+```
+
+## Example Global Structure
+
+Your `~/.claude/` might look like:
+
+```
+~/
+├── .claude.json                    # App state, OAuth, UI prefs
+└── .claude/
+    ├── CLAUDE.md                   # Personal preferences
+    ├── settings.json               # Your defaults
+    ├── keybindings.json            # Custom shortcuts
+    ├── skills/
+    │   └── my-tool/SKILL.md        # Personal skills
+    ├── output-styles/
+    │   └── teaching.md             # Custom teaching mode
+    ├── agents/
+    │   └── reviewer.md             # Personal subagents
+    └── projects/
+        └── my-project/
+            └── memory/
+                ├── MEMORY.md       # Claude's auto memory
+                └── debugging.md
+```
+
+## Inspect What Loaded
+
+The explorer shows what files **can** exist. To see what **actually loaded** in your current session:
+
+| Command        | Shows                                                                       |
+| -------------- | --------------------------------------------------------------------------- |
+| `/context`     | Token usage by category: system prompt, memory, skills, MCP tools, messages |
+| `/memory`      | Which `CLAUDE.md` and rules files loaded, plus auto-memory entries          |
+| `/agents`      | Configured subagents and their settings                                     |
+| `/hooks`       | Active hook configurations                                                  |
+| `/mcp`         | Connected MCP servers and their status                                      |
+| `/skills`      | Available skills from project, user, and plugin sources                     |
+| `/permissions` | Current allow and deny rules                                                |
+| `/doctor`      | Installation and configuration diagnostics                                  |
+
+Run `/context` first for the overview, then the specific command for the area you want to investigate.
+
+## Sources
+
+- [Explore the .claude Directory (Official Docs)](https://code.claude.com/docs/en/claude-directory)
+- [Memory](https://code.claude.com/docs/en/memory)
+- [Settings](https://code.claude.com/docs/en/settings)
+- [Settings Precedence](https://code.claude.com/docs/en/settings#settings-precedence)
+- [Server-Managed Settings](https://code.claude.com/docs/en/server-managed-settings)

--- a/features/how-claude-code-works.md
+++ b/features/how-claude-code-works.md
@@ -1,0 +1,252 @@
+# How Claude Code Works
+
+Claude Code is an agentic assistant that runs in your terminal, IDE, browser, or CI/CD pipeline. While it excels at coding, it can help with anything you can do from the command line: writing docs, running builds, searching files, researching topics, and more.
+
+This doc explains the core architecture: the agentic loop, how Claude gathers context, takes action, verifies its work, and how sessions persist across conversations. If you're new to Claude Code, start here before diving into individual features.
+
+## Overview
+
+Claude Code is an **agentic harness** around the Claude model. A language model on its own can only respond with text. Claude Code wraps the model with tools, context management, and an execution environment, turning it into a capable coding agent that can read your code, edit files, run commands, and iterate toward a goal.
+
+The architecture has two core pieces:
+
+- **Models** that reason and plan (Claude Sonnet, Opus, Haiku)
+- **Tools** that act on the world (file operations, shell commands, search, web access)
+
+Everything else (skills, MCP, hooks, subagents) extends these core pieces.
+
+## The Agentic Loop
+
+When you give Claude a task, it works through three phases: **gather context**, **take action**, and **verify results**. These phases blend together. Claude uses tools throughout, whether searching files to understand your code, editing to make changes, or running tests to check its work.
+
+![The agentic loop: prompt leads to Claude gathering context, taking action, verifying results, and repeating until task complete. You can interrupt at any point.](../resources/images/agentic-loop.svg)
+
+*Diagram source: [Claude Code official docs](https://code.claude.com/docs/en/how-claude-code-works)*
+
+The loop adapts to the task:
+
+- A **question about your codebase** might only need context gathering
+- A **bug fix** cycles through all three phases repeatedly
+- A **refactor** might involve extensive verification
+
+Claude decides what each step requires based on what it learned from the previous step, chaining dozens of actions together and course-correcting along the way.
+
+**You are part of the loop too.** You can interrupt at any point to steer Claude, add context, or ask it to try a different approach. Claude works autonomously but stays responsive to your input.
+
+## Context Gathering
+
+Claude explores your project the same way a new team member would: by reading code, searching for patterns, and checking conventions before writing anything.
+
+### What Claude Can Access
+
+When you run `claude` in a directory, Claude Code gains access to:
+
+| Source             | What It Is                                                                               |
+| ------------------ | ---------------------------------------------------------------------------------------- |
+| **Your project**   | Files in your directory and subdirectories, plus files elsewhere with your permission    |
+| **Your terminal**  | Any command you could run: build tools, git, package managers, system utilities, scripts |
+| **Your git state** | Current branch, uncommitted changes, recent commit history                               |
+| **`CLAUDE.md`**    | Project-specific instructions, conventions, and context loaded every session             |
+| **Auto memory**    | Learnings Claude saves automatically (first 200 lines or 25KB of `MEMORY.md`)            |
+| **Extensions**     | MCP servers, skills, subagents, Claude in Chrome                                         |
+
+Because Claude sees your whole project, it can work across it. When you ask Claude to "fix the authentication bug," it searches for relevant files, reads multiple files to understand context, makes coordinated edits, runs tests to verify the fix, and commits the changes if you ask. This is different from inline code assistants that only see the current file.
+
+### How Claude Explores
+
+Claude typically starts with search and exploration tools:
+
+- **Glob** to find files by pattern (e.g., `src/**/*.ts`)
+- **Grep** to search file contents with regex
+- **Read** to inspect specific files it identified during search
+- **Bash** (git commands) to understand branch state and recent history
+
+For unfamiliar codebases, Claude often reads `CLAUDE.md` first, then scans directory structure, then drills into the specific files relevant to your request.
+
+## Tool Use
+
+Tools are what make Claude Code agentic. Without tools, Claude can only respond with text. With tools, Claude can act: read your code, edit files, run commands, search the web, and interact with external services. Each tool use returns information that feeds back into the loop, informing Claude's next decision.
+
+### Tool Categories
+
+The built-in tools fall into five categories:
+
+| Category              | What Claude Can Do                                                                                                  |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **File operations**   | Read files, edit code, create new files, rename and reorganize                                                      |
+| **Search**            | Find files by pattern, search content with regex, explore codebases                                                 |
+| **Execution**         | Run shell commands, start servers, run tests, use git                                                               |
+| **Web**               | Search the web, fetch documentation, look up error messages                                                         |
+| **Code intelligence** | See type errors and warnings after edits, jump to definitions, find references (requires code intelligence plugins) |
+
+Claude also has tools for spawning subagents, asking you questions, and other orchestration tasks.
+
+### Example: Fixing Failing Tests
+
+When you say "fix the failing tests," Claude might:
+
+1. **Run the test suite** (Bash) to see what's failing
+1. **Read the error output** to understand the failure mode
+1. **Search for relevant source files** (Grep)
+1. **Read those files** (Read) to understand the code
+1. **Edit the files** (Edit) to fix the issue
+1. **Run the tests again** (Bash) to verify
+
+Each tool use gives Claude new information that informs the next step. This is the agentic loop in action.
+
+### Extending the Base Capabilities
+
+The built-in tools are the foundation. You can extend what Claude knows with:
+
+- [**Skills**](./skills.md) for reusable workflows invoked with `/name`
+- [**MCP servers**](./mcp-servers.md) to connect external services (databases, APIs, browsers)
+- [**Hooks**](./hooks.md) to run your own scripts at specific points (before a tool call, after an edit)
+- [**Subagents**](./agents.md) to offload tasks to agents with fresh context windows
+
+These extensions layer on top of the core agentic loop.
+
+## Verification
+
+Claude checks its own work as it goes. The verification phase is what separates an agent from a model that just writes code.
+
+### How Claude Verifies
+
+- **Running tests** after changes to confirm nothing broke
+- **Running linters and type checkers** to catch errors before you do
+- **Re-reading edited files** to confirm the change landed correctly
+- **Running the build** to make sure the project still compiles
+- **Running the program** to see actual behavior vs expected
+
+### Help Claude Verify
+
+Claude performs better when it has something to check against. Include:
+
+- Test cases with inputs and expected outputs
+- Screenshots of expected UI
+- Explicit success criteria in your prompt
+
+Example:
+
+```text
+Implement validateEmail. Test cases:
+'user@example.com' → true
+'invalid' → false
+'user@.com' → false
+Run the tests after.
+```
+
+When verification fails, Claude returns to the agentic loop: gather more context, try a different action, verify again.
+
+## Session Continuity
+
+Claude Code saves your conversation locally as you work. Each message, tool use, and result is stored, which enables **resuming**, **forking**, and **rewinding** sessions.
+
+![Session continuity: resume continues the same session, fork creates a new branch with a new ID.](../resources/images/session-continuity.svg)
+
+*Diagram source: [Claude Code official docs](https://code.claude.com/docs/en/how-claude-code-works)*
+
+### Resume vs Fork
+
+| Mode       | Command                                  | What Happens                                                                                               |
+| ---------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| **Resume** | `claude --continue` or `claude --resume` | Pick up where you left off. Same session ID. New messages append to the existing conversation              |
+| **Fork**   | `claude --continue --fork-session`       | Create a new session ID preserving conversation history up to that point. Original session stays unchanged |
+
+Resume is for continuing a single line of thought. Fork is for branching off to try a different approach without affecting the original.
+
+In both modes, conversation history is restored but session-scoped permissions are not. You'll need to re-approve those.
+
+### Sessions Are Independent
+
+Each new session starts with a fresh context window. Claude has no memory of previous sessions except through:
+
+- [**Auto memory**](./auto-memory.md): `MEMORY.md` that Claude maintains automatically
+- [**CLAUDE.md**](./memory-context.md): instructions you write
+
+Sessions are tied to your current directory. When you resume, you only see sessions from that directory. For parallel work, use [git worktrees](https://code.claude.com/docs/en/common-workflows#run-parallel-claude-code-sessions-with-git-worktrees) or `--fork-session`.
+
+> **Same session in multiple terminals**: Both terminals write to the same session file, and messages get interleaved. Nothing corrupts, but the conversation becomes jumbled. For parallel work from the same starting point, use `--fork-session` to give each terminal its own clean session.
+
+### Rewind with Checkpoints
+
+Before Claude edits any file, it snapshots the current contents. Press `Esc` twice to rewind to a previous state, or ask Claude to undo. See [Checkpointing](./checkpointing.md) for details.
+
+## The Context Window
+
+Claude's context window holds your conversation history, file contents, command outputs, `CLAUDE.md`, auto memory, loaded skills, and system instructions. As you work, context fills up.
+
+When context approaches the limit, Claude Code:
+
+1. **Clears older tool outputs first**
+1. **Summarizes the conversation** if needed
+
+Your requests and key code snippets are preserved; detailed instructions from early in the conversation may be lost. Put persistent rules in `CLAUDE.md` rather than relying on conversation history.
+
+Commands to inspect context:
+
+| Command    | What It Shows                                    |
+| ---------- | ------------------------------------------------ |
+| `/context` | Token usage by category                          |
+| `/memory`  | Loaded `CLAUDE.md` files and auto-memory entries |
+| `/compact` | Manually compact the conversation                |
+| `/mcp`     | Per-server MCP tool costs                        |
+
+[**Skills**](./skills.md) load on demand, and [**subagents**](./agents.md) get their own fresh context. Both help you manage long sessions without bloating the main conversation.
+
+## Execution Environments
+
+The agentic loop, tools, and capabilities are the same everywhere. What changes is where the code executes:
+
+| Environment        | Where Code Runs                         | Use Case                                            |
+| ------------------ | --------------------------------------- | --------------------------------------------------- |
+| **Local**          | Your machine                            | Default. Full access to your files and environment  |
+| **Cloud**          | Anthropic-managed VMs                   | Offload tasks, work on repos you don't have locally |
+| **Remote Control** | Your machine, controlled from a browser | Use the web UI while keeping everything local       |
+
+And the interfaces:
+
+- Terminal (CLI)
+- Desktop app (Mac/Windows)
+- IDE extensions (VS Code, JetBrains)
+- Web ([claude.ai/code](https://claude.ai/code))
+- Remote Control (mobile/web)
+- Slack, GitHub Actions, GitLab CI/CD
+
+## Working Effectively With Claude Code
+
+A few patterns that produce better results:
+
+### Be Specific Upfront
+
+The more precise your initial prompt, the fewer corrections you'll need. Reference specific files, mention constraints, point to example patterns.
+
+```text
+The checkout flow is broken for users with expired cards.
+Check src/payments/ for the issue, especially token refresh.
+Write a failing test first, then fix it.
+```
+
+### It's a Conversation
+
+You don't need perfect prompts. Start with what you want, then refine through iteration. If Claude goes down the wrong path, interrupt with a correction and it will adjust.
+
+### Explore Before Implementing
+
+For complex problems, separate research from coding. Use **plan mode** (`Shift+Tab` twice) to analyze first, then implement.
+
+```text
+Read src/auth/ and understand how we handle sessions.
+Then create a plan for adding OAuth support.
+```
+
+### Delegate, Don't Dictate
+
+Give context and direction, then trust Claude to figure out details. You don't need to specify which files to read or what commands to run.
+
+## Sources
+
+- [How Claude Code Works (Official Docs)](https://code.claude.com/docs/en/how-claude-code-works)
+- [Explore the Context Window](https://code.claude.com/docs/en/context-window)
+- [Common Workflows](https://code.claude.com/docs/en/common-workflows)
+- [Tools Reference](https://code.claude.com/docs/en/tools-reference)
+- [Features Overview](https://code.claude.com/docs/en/features-overview)

--- a/resources/images/agentic-loop.svg
+++ b/resources/images/agentic-loop.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="280" viewBox="0 0 720 280" fill="none">
+<rect width="720" height="280" rx="8" fill="#F9F9F7"/>
+
+
+<rect x="20" y="100" width="110" height="50" rx="6" fill="#E8E8E4"/>
+<text x="75" y="130" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#1E1E1E">Your prompt</text>
+
+
+<rect x="185" y="55" width="450" height="140" rx="10" fill="none" stroke="#E0E0E0" stroke-width="1.5" stroke-dasharray="6 4"/>
+<text x="410" y="75" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#9E9E9E">agentic loop</text>
+
+
+<rect x="130" y="120" width="60" height="10" fill="#F9F9F7"/>
+<path d="M130 125 L185 125" stroke="#757575" stroke-width="2"/>
+<polygon points="183,120 195,125 183,130" fill="#757575"/>
+
+
+<rect x="205" y="100" width="110" height="50" rx="6" fill="#D4E4D8"/>
+<text x="260" y="130" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600" fill="#1E1E1E">Gather context</text>
+
+
+<path d="M315 125 L345 125" stroke="#757575" stroke-width="2"/>
+<polygon points="343,120 355,125 343,130" fill="#757575"/>
+
+
+<rect x="355" y="100" width="110" height="50" rx="6" fill="#D4E4D8"/>
+<text x="410" y="130" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600" fill="#1E1E1E">Take action</text>
+
+
+<path d="M465 125 L495 125" stroke="#757575" stroke-width="2"/>
+<polygon points="493,120 505,125 493,130" fill="#757575"/>
+
+
+<rect x="505" y="100" width="110" height="50" rx="6" fill="#D4E4D8"/>
+<text x="560" y="130" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600" fill="#1E1E1E">Verify results</text>
+
+
+<path d="M560 150 L560 170 Q560 180 550 180 L270 180 Q260 180 260 170 L260 155" fill="none" stroke="#B4D4B8" stroke-width="2.5"/>
+<polygon points="255,158 260,145 265,158" fill="#B4D4B8"/>
+
+
+<rect x="615" y="120" width="25" height="10" fill="#F9F9F7"/>
+<path d="M615 125 L665 125" stroke="#757575" stroke-width="2"/>
+<polygon points="663,120 675,125 663,130" fill="#757575"/>
+
+
+<rect x="675" y="100" width="40" height="50" rx="6" fill="#E8E8E4"/>
+<text x="695" y="130" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#1E1E1E">Done</text>
+
+
+<rect x="20" y="210" width="200" height="40" rx="6" fill="#FDF6F2" stroke="#D4A27F" stroke-width="1.5"/>
+<text x="120" y="226" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#1E1E1E">You: interrupt, steer,</text>
+<text x="120" y="240" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#1E1E1E">or add context</text>
+
+
+<path d="M220 230 L410 230 L410 200" stroke="#D4A27F" stroke-width="1.5" stroke-dasharray="5 3"/>
+<polygon points="405,202 410,190 415,202" fill="#D4A27F"/>
+
+</svg>

--- a/resources/images/session-continuity.svg
+++ b/resources/images/session-continuity.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="560" height="280" viewBox="0 0 560 280" fill="none">
+<rect width="560" height="280" rx="6" fill="#F9F9F7"/>
+
+
+<text x="280" y="28" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#1E1E1E">Session continuity</text>
+
+
+<line x1="40" y1="90" x2="340" y2="90" stroke="#B4D4B8" stroke-width="3"/>
+
+
+<circle cx="60" cy="90" r="8" fill="#D4E4D8" stroke="#718057" stroke-width="2"/>
+<circle cx="120" cy="90" r="8" fill="#D4E4D8" stroke="#718057" stroke-width="2"/>
+<circle cx="180" cy="90" r="8" fill="#D4E4D8" stroke="#718057" stroke-width="2"/>
+<circle cx="240" cy="90" r="8" fill="#D4E4D8" stroke="#718057" stroke-width="2"/>
+<circle cx="300" cy="90" r="8" fill="#D4E4D8" stroke="#718057" stroke-width="2"/>
+
+
+<text x="40" y="65" font-family="ui-monospace, monospace" font-size="10" fill="#757575">session-abc123</text>
+
+
+<rect x="380" y="70" width="160" height="40" rx="4" fill="#D4E4D8"/>
+<text x="460" y="87" text-anchor="middle" font-family="ui-monospace, monospace" font-size="10" fill="#1E1E1E">claude --continue</text>
+<text x="460" y="101" text-anchor="middle" font-family="ui-monospace, monospace" font-size="10" fill="#1E1E1E">claude --resume</text>
+
+
+<path d="M375 90 L315 90" stroke="#718057" stroke-width="2"/>
+<polygon points="315,87 307,90 315,93" fill="#718057"/>
+
+
+<text x="460" y="128" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#757575">appends to same session</text>
+
+
+<text x="40" y="175" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600" fill="#1E1E1E">Fork creates a new session from any point:</text>
+
+
+<line x1="40" y1="210" x2="220" y2="210" stroke="#E8E8E4" stroke-width="2"/>
+
+
+<circle cx="60" cy="210" r="6" fill="#E8E8E4" stroke="#BDBDBD" stroke-width="1.5"/>
+<circle cx="110" cy="210" r="6" fill="#E8E8E4" stroke="#BDBDBD" stroke-width="1.5"/>
+<circle cx="160" cy="210" r="6" fill="#E8E8E4" stroke="#BDBDBD" stroke-width="1.5"/>
+
+
+<circle cx="160" cy="210" r="10" fill="none" stroke="#D4A27F" stroke-width="2"/>
+
+
+<path d="M160 210 Q180 230 200 250" stroke="#D4A27F" stroke-width="2.5" fill="none"/>
+<line x1="200" y1="250" x2="340" y2="250" stroke="#D4A27F" stroke-width="2.5"/>
+
+
+<circle cx="240" cy="250" r="6" fill="#FDF6F2" stroke="#D4A27F" stroke-width="1.5"/>
+<circle cx="290" cy="250" r="6" fill="#FDF6F2" stroke="#D4A27F" stroke-width="1.5"/>
+
+
+<rect x="380" y="230" width="160" height="40" rx="4" fill="#FDF6F2" stroke="#D4A27F" stroke-width="1.5"/>
+<text x="460" y="247" text-anchor="middle" font-family="ui-monospace, monospace" font-size="9" fill="#1E1E1E">claude --resume abc123</text>
+<text x="460" y="261" text-anchor="middle" font-family="ui-monospace, monospace" font-size="9" fill="#1E1E1E">--fork-session</text>
+
+
+<path d="M375 250 L350 250" stroke="#D4A27F" stroke-width="1.5"/>
+<polygon points="350,247 342,250 350,253" fill="#D4A27F"/>
+
+
+<text x="200" y="235" font-family="ui-monospace, monospace" font-size="9" fill="#D4A27F">session-xyz789</text>
+<text x="290" y="235" font-family="system-ui, -apple-system, sans-serif" font-size="9" fill="#757575">(new ID)</text>
+
+</svg>


### PR DESCRIPTION
## Summary
- Add how-claude-code-works.md covering the agentic loop and session continuity
- Add claude-directory.md explaining .claude/ structure
- Update README.md Quick Navigation

## Why
These are foundational conceptual docs that help readers understand Claude Code before diving into individual features.

## Sources
- [How Claude Code Works (Official Docs)](https://code.claude.com/docs/en/how-claude-code-works)
- [Claude Directory (Official Docs)](https://code.claude.com/docs/en/claude-directory)