### PR TITLE
docs: update subdomain to claude-almanac.sivura.com

### DIFF
--- a/site-planning/framework-decision.md
+++ b/site-planning/framework-decision.md
@@ -7,7 +7,7 @@
 ## Context
 
 We are building a public documentation website for claude-almanac, hosted at
-`almanac.sivura.com`. The site will expose 30+ markdown feature docs from this repo
+`claude-almanac.sivura.com`. The site will expose 30+ markdown feature docs from this repo
 to a broader audience than GitHub's markdown viewer reaches.
 
 Requirements:


### PR DESCRIPTION
## Summary
- Finalize the website subdomain as `claude-almanac.sivura.com` (matches GitHub repo name)
- Update framework-decision.md Context section

## Rationale
The subdomain matches the GitHub repo name exactly for brand consistency. Users who know the URL know the repo, and vice versa.