### PR TITLE
chore: move agent-teams-setup to guides/ with updated frontmatter

### DIFF
--- a/guides/agent-teams-setup.md
+++ b/guides/agent-teams-setup.md
@@ -1,3 +1,18 @@
+---
+title: Agent Teams Setup with Ghostty + tmux
+description: Configure your terminal environment for Claude Code agent teams
+type: guide
+category: setup
+time: 15 min
+difficulty: intermediate
+prerequisites:
+  - macOS (other platforms have partial support)
+  - Homebrew
+  - Familiarity with terminal emulators and shell config
+outcome: A Ghostty terminal running tmux, configured for Claude Code agent teams
+author: Alexander Sivura
+---
+
 # Agent Teams: Environment Setup
 
 Tools, configuration, and IDE integration for running multiple Claude Code sessions in parallel. Install these once and you're ready to use the [coordination patterns](agent-teams.md).


### PR DESCRIPTION
## Summary
- Move `features/agent-teams-setup.md` → `guides/agent-teams-setup.md`
- Update frontmatter to match guide schema (type, category, time, difficulty, prerequisites, outcome)
- Preserve body content unchanged

## Why
`agent-teams-setup` is a setup walkthrough, not a reference doc. It belongs in `guides/` per the content taxonomy (`site-planning/content-taxonomy.md`).

## URL impact
Slug stays the same: `/docs/agent-teams-setup`. No redirect needed — URL is independent of source directory.

Depends on: taxonomy-writer's PR creating the guides/ directory (merged in 7d95526).