### PR TITLE
docs: backfill frontmatter for content files

### DIFF
--- a/features/additional-features.md
+++ b/features/additional-features.md
@@ -1,3 +1,9 @@
+---
+title: Additional Features
+description: Lesser-known but powerful Claude Code features for advanced workflows.
+category: foundational
+---
+
 # Claude Code Additional Features
 
 Lesser-known but powerful features for advanced workflows.

--- a/features/agent-teams.md
+++ b/features/agent-teams.md
@@ -1,3 +1,9 @@
+---
+title: Agent Teams
+description: Multiple Claude Code instances working together on shared tasks with direct messaging and a shared task list.
+category: agents
+---
+
 # Claude Code Agent Teams
 
 Agent teams coordinate multiple independent Claude Code instances working together on a shared task. One session acts as the **team lead**, orchestrating work, while **teammates** work independently in their own context windows and communicate directly with each other.

--- a/features/agents.md
+++ b/features/agents.md
@@ -1,3 +1,9 @@
+---
+title: Agents and Subagents
+description: Specialized AI assistants that handle tasks independently with isolated context and custom tool access.
+category: agents
+---
+
 # Claude Code Agents and Subagents
 
 Agents are specialized AI assistants that handle specific types of tasks independently. Each agent runs in its own isolated context window with a custom system prompt, specific tool access controls, independent permissions, and full conversation history isolation.

--- a/features/auto-memory.md
+++ b/features/auto-memory.md
@@ -1,3 +1,9 @@
+---
+title: Auto Memory
+description: Persistent directory where Claude Code records learnings and insights as it works.
+category: foundational
+---
+
 # Auto Memory (MEMORY.md)
 
 Introduced in **Claude Code v2.1.59** (February 26, 2026), auto memory is a persistent directory where Claude Code automatically records learnings, patterns, and insights as it works. Unlike CLAUDE.md files — which are instructions you write for Claude — auto memory contains notes that Claude writes for itself based on what it discovers during sessions.

--- a/features/auto-mode.md
+++ b/features/auto-mode.md
@@ -1,3 +1,9 @@
+---
+title: Auto Mode
+description: Execute actions without permission prompts using an AI-powered safety classifier.
+category: security
+---
+
 # Claude Code Auto Mode
 
 Auto mode lets Claude execute actions without permission prompts, using a separate classifier model to block unsafe or out-of-scope operations in real time.

--- a/features/channels.md
+++ b/features/channels.md
@@ -1,3 +1,9 @@
+---
+title: Channels
+description: MCP servers that push events from external systems into a running Claude Code session.
+category: integrations
+---
+
 # Claude Code Channels
 
 Channels push events from external systems into a running Claude Code session so Claude can react to things happening outside the terminal. They are MCP servers that deliver messages, alerts, and webhooks while the session is open.

--- a/features/checkpointing.md
+++ b/features/checkpointing.md
@@ -1,3 +1,9 @@
+---
+title: Checkpointing
+description: Automatic tracking of file edits, letting you undo changes and rewind to previous states.
+category: workflows
+---
+
 # Claude Code Checkpointing
 
 Claude Code automatically tracks file edits as you work, allowing you to quickly undo changes and rewind to previous states.

--- a/features/claude-directory.md
+++ b/features/claude-directory.md
@@ -1,3 +1,9 @@
+---
+title: The .claude Directory
+description: Where Claude Code reads instructions, settings, skills, subagents, and memory.
+category: foundational
+---
+
 # The `.claude` Directory
 
 Claude Code reads instructions, settings, skills, subagents, and memory from two locations:

--- a/features/code-review.md
+++ b/features/code-review.md
@@ -1,3 +1,9 @@
+---
+title: Code Review
+description: Automated PR review using multi-agent analysis to catch logic errors, security issues, and regressions.
+category: ci-cd
+---
+
 # Claude Code Review
 
 > **Status**: Research preview. Available for Team and Enterprise subscriptions. Not available with Zero Data Retention enabled.

--- a/features/computer-use.md
+++ b/features/computer-use.md
@@ -1,3 +1,9 @@
+---
+title: Computer Use
+description: Let Claude open apps, control the screen, click, type, and take screenshots on macOS.
+category: surfaces
+---
+
 # Claude Code Computer Use
 
 > **Status**: Research preview. Requires Pro or Max plan. macOS only (CLI). Claude Code v2.1.85 or later. Not available on Team or Enterprise plans, non-interactive mode (`-p`), or third-party providers (Bedrock, Vertex, Foundry).

--- a/features/github-actions.md
+++ b/features/github-actions.md
@@ -1,3 +1,9 @@
+---
+title: GitHub Actions and CI/CD
+description: Run Claude Code in GitHub Actions workflows for automated code review, implementation, and CI/CD tasks.
+category: ci-cd
+---
+
 # Claude Code GitHub Actions and CI/CD
 
 Run Claude Code in GitHub Actions workflows for automated code review, implementation, and CI/CD tasks.

--- a/features/gitlab-cicd.md
+++ b/features/gitlab-cicd.md
@@ -1,3 +1,9 @@
+---
+title: GitLab CI/CD
+description: Integrate Claude Code into GitLab pipelines to automate code changes, MRs, and review comments.
+category: ci-cd
+---
+
 # Claude Code GitLab CI/CD
 
 > **Status**: Beta. Maintained by GitLab. Built on the Claude Code CLI and Agent SDK.

--- a/features/headless-sdk.md
+++ b/features/headless-sdk.md
@@ -1,3 +1,9 @@
+---
+title: Headless Mode and Agent SDK
+description: Run Claude Code non-interactively from the CLI or programmatically via the Python and TypeScript SDKs.
+category: surfaces
+---
+
 # Claude Code Headless Mode and Agent SDK
 
 Headless mode (now called SDK mode) allows you to run Claude Code non-interactively from the command line or within application code.

--- a/features/hooks.md
+++ b/features/hooks.md
@@ -1,3 +1,9 @@
+---
+title: Hooks
+description: Shell commands or LLM prompts that execute at specific lifecycle events during a Claude Code session.
+category: core
+---
+
 # Claude Code Hooks
 
 Hooks are a powerful automation feature that lets you execute custom bash commands or LLM-based prompts at specific points during a Claude Code session. Think of them as lifecycle events you can hook into to control, validate, or enhance Claude's behavior.

--- a/features/how-claude-code-works.md
+++ b/features/how-claude-code-works.md
@@ -1,3 +1,9 @@
+---
+title: How Claude Code Works
+description: 'The core architecture: the agentic loop, context gathering, action taking, and session persistence.'
+category: foundational
+---
+
 # How Claude Code Works
 
 Claude Code is an agentic assistant that runs in your terminal, IDE, browser, or CI/CD pipeline. While it excels at coding, it can help with anything you can do from the command line: writing docs, running builds, searching files, researching topics, and more.

--- a/features/ide-integrations.md
+++ b/features/ide-integrations.md
@@ -1,3 +1,9 @@
+---
+title: IDE Integrations
+description: Claude Code integrations with VS Code, JetBrains, desktop, web, Chrome, and the terminal.
+category: surfaces
+---
+
 # Claude Code IDE Integrations
 
 Claude Code integrates with multiple IDEs, editors, and surfaces to provide AI-assisted development directly in your workflow.

--- a/features/mcp-servers.md
+++ b/features/mcp-servers.md
@@ -1,3 +1,9 @@
+---
+title: MCP Servers
+description: Open standard for connecting Claude Code to external tools, databases, APIs, and data sources.
+category: integrations
+---
+
 # Claude Code MCP (Model Context Protocol) Servers
 
 MCP is an open-source standard for connecting AI applications to external systems. Think of MCP like a USB-C port for AI applications - it provides a standardized way to integrate Claude Code with external tools, databases, APIs, and data sources.

--- a/features/memory-context.md
+++ b/features/memory-context.md
@@ -1,3 +1,9 @@
+---
+title: Memory and Context
+description: Hierarchical memory system that maintains context across sessions and manages the context window.
+category: core
+---
+
 # Claude Code Memory and Context
 
 Claude Code uses a hierarchical memory system to maintain context across sessions and manage the context window effectively.

--- a/features/plugins.md
+++ b/features/plugins.md
@@ -1,3 +1,9 @@
+---
+title: Plugins
+description: Reusable packages that bundle custom commands, agents, hooks, MCP servers, and LSP integrations.
+category: agents
+---
+
 # Claude Code Plugins
 
 Plugins are packages of reusable functionality that extend Claude Code with custom commands, agents, hooks, MCP servers, and language server integrations.

--- a/features/pricing.md
+++ b/features/pricing.md
@@ -1,3 +1,9 @@
+---
+title: Plans and Pricing
+description: Overview of Claude plans, pricing tiers, and Claude Code feature availability per plan.
+category: workflows
+---
+
 # Claude Code Plans and Pricing
 
 Overview of all Claude plans, pricing, and Claude Code feature availability.

--- a/features/remote-control.md
+++ b/features/remote-control.md
@@ -1,3 +1,9 @@
+---
+title: Remote Control
+description: Control a terminal Claude Code session from your phone, tablet, or any browser via claude.ai.
+category: surfaces
+---
+
 # Claude Code Remote Control
 
 Control a terminal Claude Code session from your phone, tablet, or any browser. Claude keeps running entirely on your machine while you interact from anywhere.

--- a/features/rules.md
+++ b/features/rules.md
@@ -1,3 +1,9 @@
+---
+title: Rules
+description: Modular, topic-specific instruction files in .claude/rules/ for organizing project guidelines.
+category: core
+---
+
 # Claude Code Rules
 
 Modular, topic-specific instruction files for organizing project guidelines.

--- a/features/scheduled-tasks.md
+++ b/features/scheduled-tasks.md
@@ -1,3 +1,9 @@
+---
+title: Scheduled Tasks
+description: 'Three ways to schedule recurring Claude Code work: cloud, desktop app, and the /loop CLI command.'
+category: ci-cd
+---
+
 # Claude Code Scheduled Tasks
 
 Claude Code offers three ways to schedule recurring work, each suited to different needs.

--- a/features/security-sandbox.md
+++ b/features/security-sandbox.md
@@ -1,3 +1,9 @@
+---
+title: Security and Sandbox
+description: Native sandboxing, permission boundaries, and enterprise policy management for Claude Code.
+category: security
+---
+
 # Claude Code Security and Sandbox
 
 Claude Code features comprehensive security controls including native sandboxing, permission boundaries, and enterprise-grade policy management. In testing, sandboxing achieved an **84% reduction in permission prompts**, addressing approval fatigue and enabling more autonomous workflows.

--- a/features/settings.md
+++ b/features/settings.md
@@ -1,3 +1,9 @@
+---
+title: Settings and Configuration
+description: Multi-level configuration system for Claude Code settings, permissions, and customization.
+category: core
+---
+
 # Claude Code Settings and Configuration
 
 Claude Code uses a multi-level configuration system for settings, permissions, and customization.

--- a/features/skills.md
+++ b/features/skills.md
@@ -1,3 +1,9 @@
+---
+title: Slash Commands and Skills
+description: Custom actions invoked directly in conversations, unified under the Skills framework.
+category: core
+---
+
 # Claude Code Slash Commands and Skills
 
 Slash commands (starting with `/`) are custom actions you can invoke directly in Claude Code conversations. Since Claude Code unified the `.claude/commands/` system with the broader **Skills** framework, all slash commands are now implemented as skills.

--- a/features/slack-integration.md
+++ b/features/slack-integration.md
@@ -1,3 +1,9 @@
+---
+title: Claude Code in Slack
+description: Delegate coding tasks from Slack by mentioning @Claude, which creates a Claude Code session on the web.
+category: integrations
+---
+
 # Claude Code in Slack
 
 Delegate coding tasks directly from your Slack workspace. When you mention `@Claude` with a coding task, Claude detects the intent and creates a Claude Code session on the web.

--- a/features/testing.md
+++ b/features/testing.md
@@ -1,3 +1,9 @@
+---
+title: Testing Claude Code Configurations
+description: Validate Claude Code workspace configurations, skills, commands, and settings with automated tests.
+category: core
+---
+
 # Testing Claude Code Configurations
 
 Validate Claude Code workspace configurations, skills, commands, and settings with automated testing.

--- a/features/tools.md
+++ b/features/tools.md
@@ -1,3 +1,9 @@
+---
+title: Built-in Tools Reference
+description: Reference for all 18 default tools available in the Claude Code CLI, organized into six categories.
+category: core
+---
+
 # Claude Code Built-in Tools Reference
 
 Complete reference for all default tools available in Claude Code CLI.

--- a/features/ultraplan.md
+++ b/features/ultraplan.md
@@ -1,3 +1,9 @@
+---
+title: Ultraplan
+description: Draft a plan on the web in plan mode, then execute it in the cloud or send it back to the terminal.
+category: workflows
+---
+
 # Claude Code Ultraplan
 
 > **Status**: Research preview. Requires a Claude Code on the web account and a GitHub repository.

--- a/features/voice-dictation.md
+++ b/features/voice-dictation.md
@@ -1,3 +1,9 @@
+---
+title: Voice Dictation
+description: Push-to-talk voice dictation that transcribes speech live into the prompt input.
+category: surfaces
+---
+
 # Claude Code Voice Dictation
 
 Use push-to-talk voice dictation to speak prompts instead of typing them. Speech is transcribed live into the prompt input, and you can mix voice and typing in the same message.


### PR DESCRIPTION
## Summary

Adds `title`, `description`, and `category` frontmatter to every markdown file in `features/`, `guides/`, and `case-studies/`. The lenient schemas introduced in `site/source.config.ts` (PR #92) already allow the site to build without these, but sidebar grouping, cards, and per-type layouts need real frontmatter to render correctly.

### Counts

| Directory | Files backfilled |
| --- | --: |
| `features/` | 31 |
| `case-studies/` | 1 (creates the building-claude-almanac stub + frontmatter) |
| `guides/` | 0 (already done on main) |

### Field derivation

- **title**: noun phrase derived from each file's H1 (with the "Claude Code" prefix stripped for brevity)
- **description**: one-sentence summary (< 120 chars) from the intro paragraph
- **category**: chosen from the reference taxonomy in `site-planning/content-taxonomy.md` (`core`, `agents`, `integrations`, `security`, `ci-cd`, `surfaces`, `workflows`, `foundational`)

Per the site-scaffolder's decision (approved by lead), `type:` is **not** included — fumadocs-core's `multiple()` helper auto-derives it from the source directory.

### Branch

Branch `docs/backfill-frontmatter` has been reorganized — it now contains **only the single backfill commit** on top of `origin/main`. Scaffolder commits that were accidentally mixed in have been moved to their own branch (#92).

## Test plan

- [x] \`mdformat --check features/ case-studies/ guides/\` passes
- [x] Branch contains exactly one commit (the backfill) on top of origin/main
- [ ] Sidebar renders reference/guide/case-study sections with correct category grouping (verified once scaffolder PR #92 merges)

## Related

- #92 (site scaffold — separate branch, independent merge)
- #88 (slim CLAUDE.md)
- #91 (CF setup docs)
- #89 (site-build CI)