### PR TITLE
docs: add cloudflare setup docs and browser-ops agent template

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -4,12 +4,13 @@ Specialist agents for the claude-almanac repository. Spawn these via the `Agent`
 
 ## Available agents
 
-| Agent                                   | Role                         | When to use                                                 |
-| --------------------------------------- | ---------------------------- | ----------------------------------------------------------- |
-| [doc-updater](./doc-updater.md)         | Update existing feature docs | Fixing outdated content, verifying against official sources |
-| [doc-creator](./doc-creator.md)         | Create new feature docs      | Documenting features not yet covered                        |
-| [pr-reviewer](./pr-reviewer.md)         | Review and merge PRs         | After a round of doc work                                   |
-| [blog-researcher](./blog-researcher.md) | Research Anthropic sources   | Before starting doc updates                                 |
+| Agent                                                 | Role                            | When to use                                                 |
+| ----------------------------------------------------- | ------------------------------- | ----------------------------------------------------------- |
+| [doc-updater](./doc-updater.md)                       | Update existing feature docs    | Fixing outdated content, verifying against official sources |
+| [doc-creator](./doc-creator.md)                       | Create new feature docs         | Documenting features not yet covered                        |
+| [pr-reviewer](./pr-reviewer.md)                       | Review and merge PRs            | After a round of doc work                                   |
+| [blog-researcher](./blog-researcher.md)               | Research Anthropic sources      | Before starting doc updates                                 |
+| [cloudflare-browser-ops](./cloudflare-browser-ops.md) | Cloudflare dashboard operations | Inspecting CF Pages, DNS, Workers via browser (read-only)   |
 
 ## Design notes
 

--- a/.claude/agents/cloudflare-browser-ops.md
+++ b/.claude/agents/cloudflare-browser-ops.md
@@ -1,0 +1,95 @@
+---
+name: cloudflare-browser-ops
+description: Inspect and document Cloudflare account state via the dashboard using the Claude-in-Chrome extension. Use for checking CF Pages projects, DNS records, Workers, R2, and KV from the UI; capturing build configuration; and writing read-only findings to markdown. Never modifies dashboard state and never logs in on behalf of the user.
+tools: Read, Write, Edit, Grep, Glob, Bash, WebFetch, mcp__claude-in-chrome__tabs_context_mcp, mcp__claude-in-chrome__tabs_create_mcp, mcp__claude-in-chrome__switch_browser, mcp__claude-in-chrome__computer, mcp__claude-in-chrome__find, mcp__claude-in-chrome__form_input, mcp__claude-in-chrome__get_page_text, mcp__claude-in-chrome__gif_creator, mcp__claude-in-chrome__javascript_tool, mcp__claude-in-chrome__navigate, mcp__claude-in-chrome__read_console_messages, mcp__claude-in-chrome__read_network_requests, mcp__claude-in-chrome__read_page, mcp__claude-in-chrome__resize_window, mcp__claude-in-chrome__shortcuts_execute, mcp__claude-in-chrome__shortcuts_list, mcp__claude-in-chrome__update_plan, mcp__claude-in-chrome__upload_image
+model: sonnet
+---
+
+You inspect the Cloudflare dashboard via the Claude-in-Chrome extension and write findings to markdown. You are strictly **read-only** — your job is to observe account state and document it, never to change it.
+
+## What you do
+
+- Inspect CF Pages project configuration (build command, output dir, root dir, env vars, custom domains, Git connection)
+- Check DNS records and nameservers on a zone
+- Trace custom domain → Pages project → build → deployment wiring
+- List Workers, R2 buckets, KV namespaces, Durable Objects, Queues
+- Document manual setup steps a user must perform (since the agent cannot modify state)
+
+## Safety rules (non-negotiable)
+
+- **Never log in on behalf of the user.** If you land on a login page, STOP immediately and report back. The user must authenticate manually.
+- **Never modify dashboard state.** No creating projects, deleting records, rotating tokens, changing build config, adding custom domains, or clicking any button that mutates state.
+- **Never delete DNS records**, even if the user asks — tell the user to do it themselves.
+- **Never accept Terms, agreements, or consent dialogs.**
+- **Never share account IDs, API tokens, or credentials outside the repo's documentation files.** Account IDs in URLs are fine to document in markdown; treat anything labeled "secret" or "token" as off-limits.
+- When in doubt, STOP and ask the team-lead via SendMessage.
+
+## Chrome tool protocol
+
+1. **Load tools via ToolSearch first.** Chrome tools are deferred — you cannot call them until their schemas are loaded. Use `ToolSearch` with `select:mcp__claude-in-chrome__<tool_name>` (comma-separated for multiple).
+1. **Call `tabs_context_mcp` before any other browser tool.** This confirms the tab group exists and lists available tabs.
+1. **Create a new tab with `tabs_create_mcp`** rather than reusing an existing one, unless the user explicitly requests reuse.
+1. **Never trigger JavaScript dialogs** (alert, confirm, prompt) — they block the extension. Avoid clicking delete/destroy buttons entirely. If you must interact with one, warn the user first.
+1. **Use `get_page_text`** as your primary data-extraction tool for text-heavy dashboard pages. Use `read_page` with `filter: "interactive"` when you need clickable element refs.
+1. **Take screenshots** to verify state before claiming a finding. One screenshot per major transition is enough — don't spam.
+
+## Common workflows
+
+### Inspect a CF Pages project
+
+1. Navigate to `https://dash.cloudflare.com/<account_id>/workers-and-pages`
+1. `get_page_text` to list all projects
+1. Navigate to `https://dash.cloudflare.com/<account_id>/pages/view/<project>` for the project overview (deployments + custom domains visible)
+1. Click the Settings tab (or navigate to `/settings/production`)
+1. `get_page_text` to capture build command, output dir, root dir, compatibility date, Git repo
+1. For env vars: click Variables and Secrets section (values are masked for secrets)
+
+### Trace DNS for a zone
+
+1. Navigate to `https://dash.cloudflare.com/<account_id>/<zone>/dns/records`
+1. `get_page_text` captures all records + nameservers in one call
+1. For a specific subdomain, search the text output — don't iterate tools
+
+### Document CF Pages manual setup
+
+For features that cannot be inspected (because a project doesn't exist yet), write a procedural doc describing:
+
+- Exact URL to navigate to (e.g., `/workers-and-pages` → Create application → Pages → Connect to Git)
+- Each field the user must fill in, with the expected value
+- Known gotchas (Node version, root directory for monorepos, output dir differences)
+- Screenshots referenced by name if you captured them
+
+## Reporting format
+
+Write findings to a markdown file (path provided by the task). Structure:
+
+- Inspection date and account ID at the top
+- **Summary table** with one row per check (what was checked, what was found)
+- Detail sections with tables for structured data
+- "What needs to happen" section if action is required
+- "Open questions" section if you're unsure about intent
+
+## Escalation — when to stop and ask
+
+Stop and report to team-lead via SendMessage when:
+
+- You hit a login page (user is not authenticated)
+- A page returns a 404 or error (URL pattern may have changed)
+- You would need to modify state to answer the question
+- You encounter unexpected tabs, windows, or dialogs
+- The dashboard UI has changed and your findings may be stale
+
+## Style conventions
+
+- Tables for structured data (records, build config, project inventory)
+- Use `inline code` for URLs, IDs, env vars, and DNS record content
+- Cite the exact dashboard URL path where each finding came from
+- Note "read-only" methodology in the document footer
+- Dates in ISO format (YYYY-MM-DD)
+
+## Rules
+
+- NEVER add `Co-Authored-By` or "Generated with Claude Code" footers
+- Use conventional commits if asked to commit: `docs: document <subject>`
+- Don't fabricate values you didn't see on screen — if a field is hidden or masked, say so
+- Don't issue a single "browse the dashboard and tell me everything" report — focus the inspection on what the task asked for

--- a/site-planning/cloudflare-setup.md
+++ b/site-planning/cloudflare-setup.md
@@ -1,0 +1,193 @@
+# Cloudflare Pages Setup — claude-almanac
+
+- **Date**: 2026-04-04
+- **Status**: Manual setup guide (pre-scaffolding deployment prep)
+- **Prerequisite reading**: [cloudflare-state.md](./cloudflare-state.md), [site-architecture.md](./site-architecture.md)
+
+Step-by-step walkthrough for creating the Cloudflare Pages project that serves `claude-almanac.sivura.com`. Do these steps **after** the site scaffolder has landed `site/package.json` and a successful `npm run build` has been verified locally.
+
+## Target configuration at a glance
+
+| Setting                | Value                                                  |
+| ---------------------- | ------------------------------------------------------ |
+| Project name           | `claude-almanac`                                       |
+| GitHub repository      | `asivura/claude-almanac`                               |
+| Production branch      | `main`                                                 |
+| Framework preset       | `Next.js (Static HTML Export)` if available, else None |
+| Build command          | `npm run build`                                        |
+| Build output directory | `out`                                                  |
+| Root directory         | `site`                                                 |
+| Node version (env var) | `NODE_VERSION=20`                                      |
+| Automatic deployments  | Enabled                                                |
+| Build cache (Beta)     | Disabled (matches asivura-kb)                          |
+| Cloudflare Access      | Disabled (public docs site)                            |
+| Custom domain          | `claude-almanac.sivura.com`                            |
+| Account                | Asivura@gmail.com (`be59d35938cfd487927ececf20967971`) |
+
+This mirrors the working [`asivura-kb`](https://dash.cloudflare.com/be59d35938cfd487927ececf20967971/pages/view/asivura-kb/settings/production) project except:
+
+- Output dir is `out` (Next.js static export) vs. `dist`
+- `NODE_VERSION=20` is set explicitly in env vars
+
+## Prerequisites
+
+Before starting, confirm:
+
+- `site/package.json` exists in the repo with a `build` script
+- `cd site && npm install && npm run build` succeeds locally
+- `site/out/` directory is produced by the build and contains `index.html`
+- You are logged into the Cloudflare dashboard at <https://dash.cloudflare.com/> with `Asivura@gmail.com`
+- GitHub repo `asivura/claude-almanac` exists and you can access it
+
+## Step 1 — Create the Pages project
+
+1. Navigate to <https://dash.cloudflare.com/be59d35938cfd487927ececf20967971/workers-and-pages>
+1. Click **Create application** (top right)
+1. Select the **Pages** tab
+1. Click **Connect to Git**
+
+## Step 2 — Connect to GitHub
+
+1. On the "Connect to Git provider" screen, click **GitHub** if not already selected
+1. If `asivura/claude-almanac` is not listed:
+   - Click **+ Add account** or **Configure GitHub App**
+   - Grant the Cloudflare Pages GitHub app access to `asivura/claude-almanac` (repository-specific access is fine)
+   - Return to the Cloudflare tab
+1. Select `asivura/claude-almanac` from the repository list
+1. Click **Begin setup**
+
+## Step 3 — Configure build settings
+
+On the "Set up builds and deployments" screen:
+
+| Field                     | Value                                       |
+| ------------------------- | ------------------------------------------- |
+| Project name              | `claude-almanac`                            |
+| Production branch         | `main`                                      |
+| Framework preset          | **Next.js (Static HTML Export)** — see note |
+| Build command             | `npm run build`                             |
+| Build output directory    | `out`                                       |
+| Root directory (advanced) | `site`                                      |
+
+1. **Project name** defaults to the repo name; confirm it says `claude-almanac`
+1. **Production branch** should auto-populate to `main`
+1. **Framework preset**: select **Next.js (Static HTML Export)** from the dropdown. This preset auto-fills build command and output directory correctly for our static export. **Do not** choose the plain "Next.js" preset — that one assumes SSR via `@cloudflare/next-on-pages` and will fail for a static-exported build. If the dropdown does not offer a Static HTML Export option, choose **None** and fill the fields manually.
+1. **Build command**: `npm run build` (should be auto-populated by the preset)
+1. **Build output directory**: `out` (should be auto-populated by the preset)
+1. Expand **Advanced settings** and set **Root directory** to `site`
+1. **Environment variables**: click **Add variable** and add:
+   - Variable name: `NODE_VERSION`
+   - Value: `20`
+1. Click **Save and Deploy**
+
+The first build will start immediately. It will likely take 1–3 minutes. You can watch the build logs in real time.
+
+## Step 4 — Verify the first deployment
+
+1. When the build finishes (green checkmark), click **Continue to project**
+1. You should be on the project Deployments page
+1. Click the `*.claude-almanac.pages.dev` preview link to open the live site
+1. Verify the homepage loads, styles apply, navigation works
+
+If the build fails, see **Troubleshooting** below.
+
+## Step 5 — Add the custom domain
+
+1. On the project page, click the **Custom domains** tab
+1. Click **Set up a custom domain**
+1. Enter: `claude-almanac.sivura.com`
+1. Click **Continue**
+1. Cloudflare will detect that `sivura.com` is in the same account and offer to create the DNS record automatically
+1. Click **Activate domain**
+
+CF will create a proxied CNAME: `claude-almanac` → `claude-almanac.pages.dev`. SSL certificate provisioning happens automatically (Universal SSL, typically under 60 seconds).
+
+## Step 6 — Verify the custom domain
+
+1. Wait 30–60 seconds after activating
+1. Visit <https://claude-almanac.sivura.com/> in a browser
+1. Confirm HTTPS padlock, no certificate warnings
+1. Confirm the same content as the `*.pages.dev` URL
+1. Check DNS: `dig claude-almanac.sivura.com CNAME +short` should return a Cloudflare IP (proxied)
+
+## Step 7 — Verify PR preview deployments
+
+1. Create a test branch in the repo and open a draft PR against `main`
+1. Within 1–3 minutes, Cloudflare should post a preview URL comment on the PR (build comments are enabled)
+1. Click the preview URL and confirm the branch's content
+1. Close the test PR
+
+## Reference: asivura-kb as a working analog
+
+If anything behaves unexpectedly, compare against asivura-kb (same account, similar monorepo structure):
+
+| Setting              | asivura-kb           | claude-almanac (target)  |
+| -------------------- | -------------------- | ------------------------ |
+| Git repo             | `Amberflows/asivura` | `asivura/claude-almanac` |
+| Build command        | `npm run build`      | `npm run build`          |
+| Output directory     | `dist`               | `out`                    |
+| Root directory       | `site`               | `site`                   |
+| Production branch    | `main`               | `main`                   |
+| Automatic deploys    | Enabled              | Enabled                  |
+| Build cache          | Disabled             | Disabled                 |
+| Build system version | Version 3            | Version 3                |
+
+Only the output directory differs — `out` is the standard Next.js static export destination, while `dist` is whatever asivura-kb's framework uses.
+
+## Post-setup follow-ups
+
+After the project is live, the scaffolder may want to:
+
+- Add `.nvmrc` to `site/` containing `20` so local dev matches the CF build environment
+- Add an `engines.node` field to `site/package.json` for documentation
+- Enable the Build cache (Beta) once the baseline build time is known, if it exceeds ~2 min
+- Add production environment variables if any are needed (none known at this time)
+
+## Troubleshooting
+
+### Build fails with "npm: command not found"
+
+The root directory may not be set correctly. Verify in **Settings → Build → Build configuration** that **Root directory** is `site` (not empty or `/`).
+
+### Build succeeds but `out/` is empty or wrong contents
+
+- Confirm locally: `cd site && npm run build && ls out/` — there should be an `index.html`
+- For Next.js static export, `next.config.js` must have `output: 'export'`
+- Fumadocs template usually includes this by default; verify it's present
+
+### 404 on custom domain after activation
+
+- Wait up to 5 minutes for CF to propagate
+- Check <https://dash.cloudflare.com/be59d35938cfd487927ececf20967971/sivura.com/dns/records> — search for `claude-almanac` — the CNAME should be present and Proxied
+- If the record is missing, re-run Step 5 (Add custom domain)
+
+### PR preview not appearing
+
+- Check the project's **Settings → Build → Branch control** — Automatic deployments must be Enabled
+- Confirm the PR targets `main` and the branch is pushed to `asivura/claude-almanac` (not a fork)
+- Check the PR's Checks tab for Cloudflare Pages status
+
+### Node version mismatch
+
+If the build fails with "Unsupported Node version":
+
+- Confirm `NODE_VERSION=20` is set in **Settings → Variables and Secrets**
+- Alternative: add `.nvmrc` file to `site/` directory containing `20`
+
+## Rollback
+
+To revert a bad production deployment:
+
+1. Go to **Deployments** tab
+1. Find the last good deployment (green checkmark)
+1. Click the `...` menu → **Rollback to this deployment**
+
+No git revert needed — CF serves whichever deployment you designate as production.
+
+## What we did NOT configure
+
+- **CF Access** (Zero Trust preview protection) — left off; docs are public
+- **Analytics** — leave Cloudflare Web Analytics off for now; free tier is fine
+- **Workers bindings** — none needed for the static site
+- **Pages Functions** — will be added later for `Accept: text/markdown` content negotiation (see [site-architecture.md](./site-architecture.md))
+- **Custom build image / Docker** — defaults are fine

--- a/site-planning/cloudflare-state.md
+++ b/site-planning/cloudflare-state.md
@@ -1,0 +1,110 @@
+# Cloudflare Account State
+
+- **Inspection date**: 2026-04-04
+- **Inspector**: cf-browser-ops teammate (Chrome dashboard inspection, read-only)
+- **Account**: Asivura@gmail.com's Account
+- **Account ID**: `be59d35938cfd487927ececf20967971`
+- **Workers subdomain**: `asivura.workers.dev`
+
+This document captures the current state of the Cloudflare account for the `claude-almanac` site launch. All findings are read-only observations from the CF dashboard.
+
+## Summary
+
+| Check                                      | Result                                             |
+| ------------------------------------------ | -------------------------------------------------- |
+| CF Pages project named `claude-almanac`    | **Does NOT exist** — needs to be created           |
+| `sivura.com` zone in this CF account       | **Exists** on Free plan, DNS Setup: Full           |
+| DNS record for `claude-almanac.sivura.com` | **Does NOT exist** — needs to be created           |
+| Nameservers                                | `hope.ns.cloudflare.com`, `lars.ns.cloudflare.com` |
+
+## Existing Workers & Pages projects
+
+Three projects currently exist in the account:
+
+| Project      | Type                        | Domains                                            | Git                                | Last activity |
+| ------------ | --------------------------- | -------------------------------------------------- | ---------------------------------- | ------------- |
+| art-and-play | Pages                       | `art-and-play.pages.dev` + `artandplay.sivura.com` | No Git connection (direct uploads) | 10h ago       |
+| asivura-kb   | Pages                       | `asivura-kb.pages.dev` + `kb.sivura.com`           | `Amberflows/asivura`               | 12h ago       |
+| astro-whoami | Worker (with static assets) | `astro-whoami.sivura.com` + 1 other route          | `asivura/astro-whoami`             | 12d ago       |
+
+## sivura.com zone
+
+- **Plan**: Free
+- **DNS Setup**: Full (Cloudflare is authoritative)
+- **Nameservers**: `hope.ns.cloudflare.com`, `lars.ns.cloudflare.com`
+- **Advanced Certificate Manager**: Not active
+- **Worker Routes**: `astro-whoami.sivura.com` → `astro-whoami`
+
+### Existing DNS records (15 total)
+
+| Type  | Name                          | Content                                          | Proxy    |
+| ----- | ----------------------------- | ------------------------------------------------ | -------- |
+| CNAME | artandplay                    | `art-and-play.pages.dev`                         | Proxied  |
+| CNAME | console                       | `ghs.googlehosted.com`                           | Proxied  |
+| CNAME | kb                            | `asivura-kb.pages.dev`                           | Proxied  |
+| CNAME | sig1.\_domainkey              | `sig1.dkim.sivura.com.at.icloudmailadmin.com`    | DNS only |
+| MX    | send.artandplay               | `feedback-smtp.us-east-1.amazonses.com` (pri 10) | DNS only |
+| MX    | sivura.com                    | `mx01.mail.icloud.com` (pri 10)                  | DNS only |
+| MX    | sivura.com                    | `mx02.mail.icloud.com` (pri 10)                  | DNS only |
+| TXT   | \_dmarc.artandplay            | `v=DMARC1; p=none;`                              | DNS only |
+| TXT   | resend.\_domainkey.artandplay | DKIM public key (p=MIGfMA0G...)                  | DNS only |
+| TXT   | send.artandplay               | `v=spf1 include:amazonses.com ~all`              | DNS only |
+| TXT   | sivura.com                    | `v=spf1 include:icloud.com ~all`                 | DNS only |
+| TXT   | sivura.com                    | `google-site-verification=kKotJH_c8y...`         | DNS only |
+| TXT   | sivura.com                    | `google-site-verification=C-XVfn1YZa...`         | DNS only |
+| TXT   | sivura.com                    | `apple-domain=c7OocK7tcZxO4zn6`                  | DNS only |
+
+**Pattern for subdomain → Pages project**: CNAME to `<project>.pages.dev`, proxied (see `artandplay` and `kb` records). CF Pages creates this record automatically when the custom domain is added in the project's Custom domains tab.
+
+No `claude-almanac` CNAME exists yet.
+
+## Reference build config — asivura-kb
+
+The closest analog to what we'll build (static site, GitHub-integrated, `site/` subdirectory in monorepo):
+
+| Setting                | Value                |
+| ---------------------- | -------------------- |
+| Git repository         | `Amberflows/asivura` |
+| Build command          | `npm run build`      |
+| Build output directory | `dist`               |
+| Root directory         | `site`               |
+| Build comments         | Enabled              |
+| Build cache            | Disabled (Beta)      |
+| Production branch      | `main`               |
+| Automatic deployments  | Enabled              |
+| Build watch paths      | `*` (all paths)      |
+| Build system version   | Version 3            |
+| Placement              | Default              |
+| Compatibility date     | 2026-03-30           |
+| Compatibility flags    | None                 |
+
+Node version is not visible on the settings page — CF Pages uses the `NODE_VERSION` environment variable (set under Variables and Secrets) or a `.nvmrc` file in the project root. Build system v3 defaults to a recent Node LTS if unset.
+
+## What needs to happen for claude-almanac
+
+To deploy `claude-almanac.sivura.com`, a scaffolder will need to:
+
+1. **Create a new CF Pages project** named `claude-almanac` connected to the `asivura/claude-almanac` (or wherever it ends up) GitHub repo
+1. **Set build configuration**:
+   - Build command: `npm run build`
+   - Build output directory: `out` (Fumadocs/Next.js static export default)
+   - Root directory: `site`
+   - Production branch: `main`
+1. **Set environment variables**:
+   - `NODE_VERSION=20` (or 22) — Next.js 15 requires Node 18.17+
+1. **Add custom domain** `claude-almanac.sivura.com` in the project's Custom domains tab (CF auto-creates the CNAME proxied record)
+1. **Verify preview deployments** work on non-main branches
+
+## Inspection methodology
+
+- Chrome-in-browser tool used against `dash.cloudflare.com` (user was already logged in)
+- Read-only: no settings were modified, no clicks on destructive actions
+- Pages listed at `/workers-and-pages`
+- Zone DNS at `/<account>/sivura.com/dns/records`
+- Project build config at `/<account>/pages/view/<project>/settings/production`
+
+## Open questions for team-lead
+
+- Which GitHub org will host the site repo? (assuming `asivura/claude-almanac` based on existing public repos pattern, since claude-almanac is public)
+- Should we enable the Build cache (Beta) on the new project? asivura-kb has it off.
+- Do we want preview deployment access controls? (Cloudflare Access is currently not enabled on any sivura.com project)


### PR DESCRIPTION
## Summary

Three deliverables from the cf-browser-ops teammate that inspected the Cloudflare account for the site deploy:

- **`site-planning/cloudflare-state.md`** — read-only inspection of the Cloudflare account. Documents existing Pages projects (art-and-play, asivura-kb, astro-whoami), sivura.com zone DNS records, and identifies asivura-kb as the closest reference analog for claude-almanac (static site, GitHub-integrated, monorepo `site/` subdir)
- **`site-planning/cloudflare-setup.md`** — actionable step-by-step dashboard walkthrough to create the `claude-almanac` Pages project. Covers: creating project → connecting asivura/claude-almanac → build config (npm run build, root=site, output=out, NODE_VERSION=20) → first deploy verification → custom domain claude-almanac.sivura.com → PR preview verification. Includes troubleshooting + rollback steps.
- **`.claude/agents/cloudflare-browser-ops.md`** — reusable agent template for future CF dashboard operations via Chrome extension. Read-only by default, with explicit safety rules (never log in, never mutate without confirmation, stop and report if user isn't logged in).

## Background

These files were produced by the `cf-browser-ops` teammate during the site launch effort. They're infrastructure/setup documentation and belong on their own branch separate from the Fumadocs scaffold work (see #88 and feat/scaffold-fumadocs-site).

## Test plan

- [x] \`mdformat --check\` passes on all 4 files
- [x] \`.claude/agents/README.md\` updated to list cloudflare-browser-ops
- [ ] User follows cloudflare-setup.md to create the CF Pages project