### PR TITLE
docs: add site development sections to root docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,26 @@ Pre-commit hooks will catch anything missed, but running manually avoids the pre
 
 Prefer the project-scoped specialists in `.claude/agents/` over generic subagents — they know this repo's conventions. See `.claude/agents/README.md` for the catalog (doc-updater, doc-creator, blog-researcher, pr-reviewer, cloudflare-browser-ops).
 
+## Website development
+
+Local preview of the Fumadocs site:
+
+```bash
+cd site
+npm install   # first time only
+npm run dev   # → http://localhost:3000
+```
+
+Production build (static export to `site/out/`):
+
+```bash
+cd site && npm run build
+```
+
+The build reads content from `../features/`, `../guides/`, `../case-studies/` at the repo root, and copies images from `../resources/images/` into `site/public/images/` via a prebuild script (`scripts/copy-images.mjs`). No content lives inside `site/` — the site is just the rendering layer.
+
+Deploy: Cloudflare Pages auto-builds and deploys on every push to `main`. PR branches get preview URLs. See `site-planning/cloudflare-setup.md` for the project setup and `site/DEPLOY.md` for post-deploy verification.
+
 ## Design system (website)
 
 The website uses **Fumadocs** (Next.js 15 + Tailwind CSS v4 + shadcn/ui). The visual theme is the **"claude-almanac"** preset on [tweakcn.com](https://tweakcn.com/editor/theme) — warm terracotta primary on cream background, matching Anthropic's Claude brand palette.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,24 @@ Rules:
 - No period at the end
 - Subject line: max 72 characters
 
+### Local site preview
+
+The Fumadocs site that renders at [claude-almanac.sivura.com](https://claude-almanac.sivura.com) lives in `site/`. To preview changes locally before opening a PR:
+
+```bash
+cd site
+npm install   # first time only
+npm run dev   # → http://localhost:3000
+```
+
+The site reads markdown from `features/`, `guides/`, and `case-studies/` at the repo root — no need to move or copy content into `site/`. Edits to any content file hot-reload in the dev server.
+
+For a production build (what Cloudflare Pages runs):
+
+```bash
+cd site && npm run build
+```
+
 ### Pull request workflow
 
 Direct pushes to `main` are blocked. All changes require PRs.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Comprehensive documentation of Claude Code's extensibility features and capabilities for optimizing workflows and enhancing user experience.
 
+## Website
+
+Rendered version: **[claude-almanac.sivura.com](https://claude-almanac.sivura.com)**
+
+The markdown files in this repo are the source of truth. They're rendered by a Fumadocs site in `site/` which auto-deploys to Cloudflare Pages on every push to `main`. To preview locally: `cd site && npm install && npm run dev`. See [CONTRIBUTING.md](./CONTRIBUTING.md) for more.
+
 ## Quick Navigation
 
 | Feature                                                      | Description            | Use When                                                    |


### PR DESCRIPTION
## Summary

Adds site/ documentation to the three repo-root doc files, so contributors and LLMs know how to preview and deploy the website:

- **README.md**: Website section at the top with live URL + local preview command
- **CLAUDE.md**: Website development section (local dev, build, content flow, deploy model)
- **CONTRIBUTING.md**: Local site preview subsection under Development

## Scope

~44 lines added across 3 files. No content removed, no restructuring.

## Dependencies

None. These docs reference \`site/\` paths that land via PR #92, but we already have the same pattern in \`site-planning/cloudflare-setup.md\` (already on main) referencing site/ paths.

## Test plan

- [x] \`mdformat --check\` passes on all 3 files
- [x] No content removed from existing files
- [x] Links to CONTRIBUTING.md, site-planning/cloudflare-setup.md, site/DEPLOY.md remain valid (last one only after #92 merges)

## Related

Closes #12 (task from almanac-site-launch team).
Related PRs: #92 (scaffold), #90 (frontmatter), #89 (CI).