### PR TITLE
fix(site): redirect /docs to first doc

### DIFF
--- a/site/public/_redirects
+++ b/site/public/_redirects
@@ -1,0 +1,1 @@
+/docs /docs/hooks 302


### PR DESCRIPTION
## Summary

\`/docs\` returns **404** on production because Next.js static export doesn't generate \`/docs/index.html\` for the empty-slug case in the \`[[...slug]]\` catch-all. Visitors clicking "open /docs" from the homepage hit a 404 wall.

Adds \`site/public/_redirects\`:

\`\`\`
/docs /docs/hooks 302
\`\`\`

Cloudflare Pages applies \`_redirects\` files natively.

## Why 302

Temporary redirect — this lets us swap in a real docs-index page later (grouped category listing, search, etc.) without breaking existing 301 caching.

## Not fixed here

\`/docs/<slug>.md\` also 404s — Fumadocs puts per-page markdown at \`/llms.mdx/docs/<slug>/content.md\`, not \`/docs/<slug>.md\`. Separate fix. Agents can still use \`Accept: text/markdown\` via the existing Pages Function middleware.

## Test plan

- [ ] After merge + CF deploy, \`curl -I https://claude-almanac.sivura.com/docs\` returns 302 with Location: /docs/hooks