### PR TITLE
feat: add security response headers for static site

### DIFF
--- a/site/public/_headers
+++ b/site/public/_headers
@@ -1,0 +1,7 @@
+/*
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: geolocation=(), microphone=(), camera=()
+  Strict-Transport-Security: max-age=31536000; includeSubDomains
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'


### PR DESCRIPTION
## Summary
- Adds `site/public/_headers` with security response headers served by Cloudflare Pages for all paths (`/*`).
- Includes: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy` (disables geolocation/mic/camera), `Strict-Transport-Security: max-age=31536000; includeSubDomains`, and a `Content-Security-Policy`.
- Verified the static export still builds (`npm run build`) and `_headers` is copied to `site/out/_headers`.

## CSP verification needed before merge
The CSP policy is the riskiest piece — it could break scripts/styles in production. It cannot be fully tested locally because `_headers` is only applied by Cloudflare Pages. **Before merging, verify on the PR's Cloudflare Pages preview deployment that:**
- Pages render without CSP console violations (check DevTools console).
- Search/nav interactions still work.
- OG images / fonts / code highlighting load correctly.

If the CSP blocks legitimate assets, relax the appropriate directive (likely adding hashes or specific hosts) and push a fixup before merge.

## Test plan
- [x] `npm run build` succeeds.
- [x] `_headers` copied into `site/out/`.
- [ ] Cloudflare Pages preview deploy: no CSP violations in browser console.
- [ ] Security headers visible in `curl -I` against preview URL.

Closes #95