### PR TITLE
docs: elevate website link to top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
 # Claude Code Features Reference
 
-Comprehensive documentation of Claude Code's extensibility features and capabilities for optimizing workflows and enhancing user experience.
+**Read online: [claude-almanac.sivura.com](https://claude-almanac.sivura.com/)**
 
-## Website
-
-Rendered version: **[claude-almanac.sivura.com](https://claude-almanac.sivura.com)**
-
-The markdown files in this repo are the source of truth. They're rendered by a Fumadocs site in `site/` which auto-deploys to Cloudflare Pages on every push to `main`. To preview locally: `cd site && npm install && npm run dev`. See [CONTRIBUTING.md](./CONTRIBUTING.md) for more.
+Comprehensive documentation of Claude Code's extensibility features and capabilities for optimizing workflows and enhancing user experience. The markdown files in this repo are the source of truth — they're rendered by a Fumadocs site in `site/` that auto-deploys to Cloudflare Pages on every push to `main`. See [CONTRIBUTING.md](./CONTRIBUTING.md) for local preview and contribution guidelines.
 
 ## Quick Navigation
 


### PR DESCRIPTION
## Summary

Moves the claude-almanac.sivura.com link from a buried \`## Website\` H2 section to a prominent standalone bold line directly under the H1 title.

## Before

\`\`\`
# Claude Code Features Reference

Comprehensive documentation...

## Website

Rendered version: **[claude-almanac.sivura.com](...)**
...
\`\`\`

## After

\`\`\`
# Claude Code Features Reference

**Read online: [claude-almanac.sivura.com](https://claude-almanac.sivura.com/)**

Comprehensive documentation... [merged site context into description]
\`\`\`

## Why

GitHub social preview and above-the-fold repo page placement — the live site URL should be the first thing a visitor sees after the title. Removes the redundant H2 and the extra paragraph; merges the site context into the main description.

## Test plan

- [x] \`mdformat --check README.md\` passes
- [x] Link resolves (claude-almanac.sivura.com is live)