### PR TITLE
fix(site): correct content path in github URL for doc pages

### DIFF
--- a/site/src/app/docs/[[...slug]]/page.tsx
+++ b/site/src/app/docs/[[...slug]]/page.tsx
@@ -51,6 +51,16 @@ export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
   };
   const type = data.type;
 
+  // Map the collection type to the source directory at the repo root.
+  // Content lives at repo root in three directories (not in site/content/docs/)
+  // so the GitHub URL must reflect the actual source path.
+  const contentDirByType: Record<string, string> = {
+    reference: 'features',
+    guide: 'guides',
+    caseStudy: 'case-studies',
+  };
+  const contentDir = contentDirByType[type ?? 'reference'] ?? 'features';
+
   return (
     <DocsPage toc={page.data.toc} full={page.data.full}>
       <DocsTitle>{page.data.title}</DocsTitle>
@@ -59,7 +69,7 @@ export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
         <MarkdownCopyButton markdownUrl={markdownUrl} />
         <ViewOptionsPopover
           markdownUrl={markdownUrl}
-          githubUrl={`https://github.com/${gitConfig.user}/${gitConfig.repo}/blob/${gitConfig.branch}/content/docs/${page.path}`}
+          githubUrl={`https://github.com/${gitConfig.user}/${gitConfig.repo}/blob/${gitConfig.branch}/${contentDir}/${page.path}`}
         />
       </div>
 


### PR DESCRIPTION
## Bug

'Open in GitHub' on every /docs/* page returns **404**. The githubUrl hardcoded \`content/docs/\` as the content directory, but claude-almanac keeps content at the repo root in three dirs (\`features/\`, \`guides/\`, \`case-studies/\`).

**Before**: \`github.com/asivura/claude-almanac/blob/main/content/docs/tools.md\` → 404
**After**: \`github.com/asivura/claude-almanac/blob/main/features/tools.md\` → 200

## Fix

Maps \`page.data.type\` (reference|guide|caseStudy) to the correct source directory:
- \`reference\` → \`features\`
- \`guide\` → \`guides\`
- \`caseStudy\` → \`case-studies\`

## Test plan

- [x] tsc clean (type-safe with Record<string, string> + fallback)
- [ ] After deploy: 'Open in GitHub' on /docs/tools → features/tools.md (200)
- [ ] After deploy: 'Open in GitHub' on /docs/agent-teams-setup → guides/agent-teams-setup.md (200)
- [ ] After deploy: 'Open in GitHub' on /docs/building-claude-almanac → case-studies/building-claude-almanac.md (200)