### PR TITLE
fix(docs): repair broken agent-teams-setup link

### DIFF
--- a/features/agent-teams.md
+++ b/features/agent-teams.md
@@ -10,7 +10,7 @@ Agent teams coordinate multiple independent Claude Code instances working togeth
 
 > **Status**: Experimental. Requires Claude Code v2.1.32+.
 
-For environment setup (Ghostty, tmux, Starship, VS Code integration), see [Agent Teams: Environment Setup](agent-teams-setup.md).
+For environment setup (Ghostty, tmux, Starship, VS Code integration), see [Agent Teams: Environment Setup](/docs/agent-teams-setup).
 
 ## Overview
 
@@ -430,4 +430,4 @@ tmux kill-session -t <session-name>
 - [Subagents Documentation](https://code.claude.com/docs/en/sub-agents)
 - [Hooks Documentation](https://code.claude.com/docs/en/hooks)
 - [Agent Team Token Costs](https://code.claude.com/docs/en/costs#agent-team-token-costs)
-- [Agent Teams: Environment Setup](agent-teams-setup.md) - Ghostty, tmux, Starship, and VS Code integration
+- [Agent Teams: Environment Setup](/docs/agent-teams-setup) - Ghostty, tmux, Starship, and VS Code integration


### PR DESCRIPTION
## Bug

The \"Agent Teams: Environment Setup\" link on https://claude-almanac.sivura.com/docs/agent-teams uses \`[...](agent-teams-setup.md)\` which resolves to \`/docs/agent-teams-setup.md\` → **404**.

## Root cause

\`features/agent-teams.md\` linked to \`agent-teams-setup.md\` via a relative path, expecting it to be in the same directory. But \`agent-teams-setup.md\` was moved to \`guides/\` during the content taxonomy reorganization. Fumadocs' relative link resolver can't cross content collections, so it kept the \`.md\` suffix in the href.

## Fix

Replace the 2 relative references with absolute \`/docs/agent-teams-setup\` URL paths. Cross-collection links in this repo should always use \`/docs/<slug>\` absolute paths — relative \`.md\` paths only work within a single content directory.

## Test plan

- [x] mdformat --check passes
- [ ] After deploy, visit https://claude-almanac.sivura.com/docs/agent-teams and click \"Agent Teams: Environment Setup\" → should open /docs/agent-teams-setup (200)