### PR TITLE
fix(docs): agent-teams-setup link works on both GitHub and site

### DIFF
--- a/features/agent-teams.md
+++ b/features/agent-teams.md
@@ -10,7 +10,7 @@ Agent teams coordinate multiple independent Claude Code instances working togeth
 
 > **Status**: Experimental. Requires Claude Code v2.1.32+.
 
-For environment setup (Ghostty, tmux, Starship, VS Code integration), see [Agent Teams: Environment Setup](/docs/agent-teams-setup).
+For environment setup (Ghostty, tmux, Starship, VS Code integration), see [Agent Teams: Environment Setup](../guides/agent-teams-setup.md).
 
 ## Overview
 
@@ -430,4 +430,4 @@ tmux kill-session -t <session-name>
 - [Subagents Documentation](https://code.claude.com/docs/en/sub-agents)
 - [Hooks Documentation](https://code.claude.com/docs/en/hooks)
 - [Agent Team Token Costs](https://code.claude.com/docs/en/costs#agent-team-token-costs)
-- [Agent Teams: Environment Setup](/docs/agent-teams-setup) - Ghostty, tmux, Starship, and VS Code integration
+- [Agent Teams: Environment Setup](../guides/agent-teams-setup.md) - Ghostty, tmux, Starship, and VS Code integration


### PR DESCRIPTION
## Context

PR #118 fixed the broken link on the deployed site by using \`/docs/agent-teams-setup\`. But that site-absolute path doesn't work when \`features/agent-teams.md\` is viewed directly on GitHub.com — GitHub resolves \`/docs/...\` as a repo-relative path (\`github.com/asivura/claude-almanac/docs/...\`) which 404s.

This repo's markdown files are dual-rendered (GitHub + Fumadocs site), so links need to work in both contexts.

## Fix

Switch to cross-dir relative path: \`../guides/agent-teams-setup.md\`

- **GitHub**: resolves as \`features/../guides/agent-teams-setup.md\` → the actual file location ✓
- **Fumadocs site**: \`createRelativeLink(source, page)\` is wired into the MDX \`a\` component override. It resolves the cross-dir relative through the unified source loader, returning \`/docs/agent-teams-setup\` ✓

## Convention going forward

Cross-collection links in this repo should use file-relative paths with \`../\`, not site-absolute \`/docs/\` paths. Will document in CLAUDE.md as a follow-up.

## Test plan

- [x] mdformat --check passes
- [ ] After deploy: click link on https://claude-almanac.sivura.com/docs/agent-teams → opens /docs/agent-teams-setup
- [ ] After deploy: view features/agent-teams.md on GitHub → click link → opens guides/agent-teams-setup.md file