### PR TITLE
refactor(site): switch default theme from dark to light

### DIFF
--- a/site/src/components/provider.tsx
+++ b/site/src/components/provider.tsx
@@ -6,7 +6,7 @@ import { type ReactNode } from 'react';
 export function Provider({ children }: { children: ReactNode }) {
   return (
     <RootProvider
-      theme={{ defaultTheme: 'dark' }}
+      theme={{ defaultTheme: 'light' }}
       search={{ SearchDialog }}
     >
       {children}


### PR DESCRIPTION
## Summary

Revert the dark-default shipped in #117. Reasons:

1. **Theme was designed light-first** — tweakcn tokens have light at \`:root\`, dark as \`.dark\` override. Terracotta (#c96442) + cream (#faf9f5) is the Claude brand palette.
2. **Images render correctly in light** — the dark-mode \`filter: invert\` hack (also from #117) is needed because white-bg/transparent diagrams clash with dark. In light mode, diagrams look native, semantic colors preserved.
3. **Matches visitor expectation** — most docs sites (shadcn, Next.js, Anthropic's own) default to light or system.

next-themes persists the toggle, so users who prefer dark switch once and stay dark.

## What's NOT changed

- Image-invert CSS in \`global.css\` — stays (only fires in \`.dark\` scope, still needed when users toggle dark)
- The AI-button popover replacement — stays
- The Claude Almanac rebrand — stays
- Everything else from #117 — stays

## Test plan

- [x] \`npm run build\` passes
- [ ] After deploy: first-visit (incognito) loads in light mode
- [ ] Dark toggle still works and persists