### PR TITLE
refactor(site): wrap images in light card in dark mode (replaces invert)

### DIFF
--- a/site/src/app/global.css
+++ b/site/src/app/global.css
@@ -24,13 +24,15 @@ html > body[data-scroll-locked] {
   --removed-body-scroll-bar-size: 0px !important;
 }
 
-/* Dark mode: invert images so diagrams with black text on transparent or
- * white backgrounds render readably. Uses invert + hue-rotate to preserve
- * hues approximately (blues stay blue-ish, reds stay red-ish).
+/* Dark mode: wrap images in a cream surface so light-authored content
+ * (diagrams, colored flowcharts, photos, screenshots) renders with its
+ * original colors intact. Preserves every pixel without filter hacks.
  *
- * Opt-out with class="no-invert" or data-no-invert for terminal
- * screenshots, photos, or images with dark-by-design backgrounds.
+ * Opt-out with class="dark-optimized" or data-dark-optimized for
+ * images that were designed for dark backgrounds.
  */
-.dark img:not(.no-invert):not([data-no-invert]) {
-  filter: invert(1) hue-rotate(180deg);
+.dark img:not(.dark-optimized):not([data-dark-optimized]) {
+  background-color: #faf9f5;
+  padding: 0.5rem;
+  border-radius: 0.375rem;
 }


### PR DESCRIPTION
## Summary

Replace the CSS \`filter: invert(1) hue-rotate(180deg)\` from #117 with a light card wrap.

## Why the switch

When dark was the default (#117), image-invert had to \"look decent for every visitor.\" After #120 flipped default to light, dark mode is a minority view. Users who toggle dark:

- Chose it explicitly
- Accept minor aesthetic tradeoffs
- Need images to be **readable and accurate**, not \"natively dark-integrated\"

The invert approach broke colored diagrams (lightness flipped → light pink box becomes dark pink box, etc.). The card wrap preserves every pixel.

## The rule

\`\`\`css
.dark img:not(.dark-optimized):not([data-dark-optimized]) {
  background-color: #faf9f5;
  padding: 0.5rem;
  border-radius: 0.375rem;
}
\`\`\`

## Opt-out renamed

\`.no-invert\` → \`.dark-optimized\`. Describes the image's design intent (\"this image was designed for dark backgrounds\") rather than the CSS technique.

Not currently used in any content file — no backwards-compat break.

## Test plan

- [x] CSS syntax verified
- [ ] After deploy: toggle to dark mode on /docs/agent-teams, verify the agent-teams-vs-subagents diagram shows original pink/orange/blue/purple colors on a cream card
- [ ] Verify no visual regression on light mode
- [ ] Spot-check other diagram-heavy pages