### PR TITLE
refactor(site): restore image invert for dark mode

### DIFF
--- a/site/src/app/global.css
+++ b/site/src/app/global.css
@@ -24,15 +24,20 @@ html > body[data-scroll-locked] {
   --removed-body-scroll-bar-size: 0px !important;
 }
 
-/* Dark mode: wrap images in a cream surface so light-authored content
- * (diagrams, colored flowcharts, photos, screenshots) renders with its
- * original colors intact. Preserves every pixel without filter hacks.
+/* Dark mode: invert images via filter so light-background diagrams
+ * (the Anthropic blog's flowcharts and architecture diagrams being
+ * the bulk of our images) integrate visually with the dark page.
  *
- * Opt-out with class="dark-optimized" or data-dark-optimized for
- * images that were designed for dark backgrounds.
+ * invert(1) flips lightness; hue-rotate(180deg) approximately
+ * preserves hues, so pink stays pink-ish (darker), blue stays
+ * blue-ish (darker), etc. Not pixel-perfect color fidelity, but
+ * colors remain recognizable and the image feels native to dark
+ * mode rather than pasted on as a light rectangle.
+ *
+ * Opt out with class="dark-optimized" or data-dark-optimized for
+ * images that were designed for dark backgrounds (terminal
+ * screenshots, dark-themed captures, photos).
  */
 .dark img:not(.dark-optimized):not([data-dark-optimized]) {
-  background-color: #faf9f5;
-  padding: 0.5rem;
-  border-radius: 0.375rem;
+  filter: invert(1) hue-rotate(180deg);
 }


### PR DESCRIPTION
## Summary

Reverts #121's cream-card-wrap back to the CSS invert filter.

## Why revert

User tested in dark mode after #121 deployed — the cream cards create visible light rectangles on every image, breaking the dark-theme flow. For the site's content (95%+ light-bg diagrams from Anthropic blog), invert produces better visual integration.

## Tradeoff

Colors shift under invert (light pink → darker pink-maroon, etc.) but remain in the same hue family and recognizable. Not pixel-perfect, but semantic color coding (pink=Main Agent, orange=Subagent) still reads correctly.

## Preserved

- \`.dark-optimized\` / \`[data-dark-optimized]\` opt-out class (cleaner name than original .no-invert)
- Opt-out mechanism for photos / terminal screenshots / dark-themed images

## Test plan

- [ ] After deploy: toggle dark mode, verify diagrams integrate with dark page (no cream cards)
- [ ] Verify text is readable and colors recognizable
- [ ] Add \`.dark-optimized\` to specific images that look wrong (expected: very few)