### PR TITLE
feat(site): return markdown 404 when Accept: text/markdown

### DIFF
--- a/site-planning/content-negotiation-decision.md
+++ b/site-planning/content-negotiation-decision.md
@@ -71,35 +71,67 @@ Cloudflare Pages Function, complementing Fumadocs' built-in llms.txt and
 
 ## Implementation
 
-Minimal Pages Function at `site/functions/_middleware.ts`:
+Pages Function at `site/functions/_middleware.ts` (simplified):
 
 ```typescript
 export const onRequest: PagesFunction = async ({ request, next }) => {
-  const accept = request.headers.get('Accept') || '';
+  const accept = request.headers.get('Accept') ?? '';
   const url = new URL(request.url);
 
-  if (accept.includes('text/markdown') && url.pathname.startsWith('/docs/')) {
-    const mdUrl = new URL(url);
-    mdUrl.pathname = url.pathname.replace(/\/$/, '') + '.md';
-
-    const mdResponse = await fetch(mdUrl.toString());
-    if (mdResponse.ok) {
-      const text = await mdResponse.text();
-      const estimatedTokens = Math.ceil(text.length / 4);
-
-      return new Response(text, {
-        headers: {
-          'Content-Type': 'text/markdown; charset=utf-8',
-          'X-Markdown-Tokens': estimatedTokens.toString(),
-          'Vary': 'Accept',
-        }
-      });
-    }
+  // Browsers + non-/docs requests fall through to static HTML.
+  if (!accept.includes('text/markdown') || !url.pathname.startsWith('/docs/')) {
+    return next();
   }
 
-  return next();
+  // Validate slug, reject anything outside [a-z0-9-].
+  const slug = url.pathname.replace(/^\/docs\/?/, '').replace(/\/$/, '');
+  if (slug && !/^[a-z0-9-]+$/.test(slug)) return markdownNotFound(url.pathname);
+
+  // Fumadocs places per-page markdown at /llms.mdx/docs/<slug>/content.md.
+  // Bare /docs/ maps to the top-level /llms.txt index.
+  const mdPath = slug ? `/llms.mdx/docs/${slug}/content.md` : '/llms.txt';
+  const mdResponse = await fetch(new URL(mdPath, url.origin).toString());
+
+  if (!mdResponse.ok) return markdownNotFound(url.pathname);
+
+  const text = await mdResponse.text();
+  return new Response(text, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'X-Markdown-Tokens': Math.ceil(text.length / 4).toString(),
+      'Vary': 'Accept',
+      'Cache-Control': 'public, max-age=300, s-maxage=3600',
+    },
+  });
 };
 ```
+
+See `site/functions/_middleware.ts` for the full implementation including
+the `markdownNotFound` helper, extra guards, and comments.
+
+### URL mapping
+
+| Client request                   | Internal fetch                     |
+| -------------------------------- | ---------------------------------- |
+| `/docs/<slug>`                   | `/llms.mdx/docs/<slug>/content.md` |
+| `/docs/<slug>/` (trailing slash) | `/llms.mdx/docs/<slug>/content.md` |
+| `/docs/` (bare)                  | `/llms.txt`                        |
+
+### Error responses
+
+When the internal fetch returns 404 — or the slug fails regex validation
+— the middleware returns a **markdown 404 response** instead of falling
+through to the HTML 404 page. This keeps content negotiation consistent
+end-to-end for markdown-accepting clients (agents get markdown for both
+successes AND errors).
+
+The 404 body is a markdown document with recovery links (`/llms.txt`,
+`/llms-full.txt`, `/docs`) plus a GitHub issues link, so agents can
+self-navigate. Browsers (`Accept: text/html`) are unaffected — they
+still hit `next()` via the early-return guard.
+
+The requested pathname is embedded in a code span in the response body,
+sanitized first (stripping backticks/backslashes, capping at 200 chars).
 
 ## Consequences
 
@@ -111,9 +143,12 @@ export const onRequest: PagesFunction = async ({ request, next }) => {
   treatment. Landing page, 404, etc. don't.
   *Mitigation*: Those pages are for humans anyway; agents want docs content.
 - **No automatic HTML→MD conversion**: Unlike CF's feature, we can only serve
-  pre-generated markdown. If someone hits a route without a `.md` sibling,
-  they get HTML.
-  *Mitigation*: Fumadocs generates `.md` for every docs route by default.
+  pre-generated markdown. If someone hits `/docs/<slug>` with no corresponding
+  content in Fumadocs' generated markdown tree, they get a markdown 404 body
+  (not HTML, not a crash).
+  *Mitigation*: Fumadocs generates `/llms.mdx/docs/<slug>/content.md` for
+  every docs route by default; the middleware fetches from that path. Missing
+  slugs return markdown 404 responses (see Error responses above).
 
 ### Benefits
 

--- a/site/functions/_middleware.ts
+++ b/site/functions/_middleware.ts
@@ -4,6 +4,10 @@
 // the Fumadocs-generated markdown sibling instead of HTML. Browsers (Accept:
 // text/html, */*) fall through to the static HTML export.
 //
+// Error handling: markdown-accepting clients also get a markdown 404 body
+// when the page doesn't exist (instead of falling through to the HTML 404
+// page) — keeps content negotiation consistent end-to-end.
+//
 // See site-planning/content-negotiation-decision.md for full rationale.
 //
 // URL mapping:
@@ -19,6 +23,34 @@ type PagesFunction = (context: {
   request: Request;
   next: () => Promise<Response>;
 }) => Promise<Response>;
+
+function markdownNotFound(pathname: string): Response {
+  // Sanitize pathname for safe embedding in the markdown body: strip
+  // backticks and backslashes so a crafted URL can't break out of the
+  // code span, and cap the length.
+  const displayPath = pathname.replace(/[`\\]/g, '').slice(0, 200);
+  const body = `# 404 Not Found
+
+The page \`${displayPath}\` does not exist on claude-almanac.sivura.com.
+
+## Find what you're looking for
+
+- **Full index**: [/llms.txt](/llms.txt)
+- **All content**: [/llms-full.txt](/llms-full.txt)
+- **Documentation**: [/docs](/docs)
+
+If you expected this page to exist, open an issue at
+https://github.com/asivura/claude-almanac/issues.
+`;
+  return new Response(body, {
+    status: 404,
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'X-Markdown-Tokens': Math.ceil(body.length / 4).toString(),
+      Vary: 'Accept',
+    },
+  });
+}
 
 export const onRequest: PagesFunction = async ({ request, next }) => {
   const accept = request.headers.get('Accept') ?? '';
@@ -40,10 +72,10 @@ export const onRequest: PagesFunction = async ({ request, next }) => {
 
   // Guard: slugs must match our known content pattern (lowercase, digits,
   // hyphens only). Anything else is either a typo or an attempt at path
-  // traversal / URL injection — fall through to the static HTML so the
-  // platform's own 404 handles it.
+  // traversal / URL injection — return a markdown 404 so markdown-accepting
+  // clients get a consistent response type.
   if (slug && !/^[a-z0-9-]+$/.test(slug)) {
-    return next();
+    return markdownNotFound(url.pathname);
   }
 
   const mdPath = slug
@@ -57,8 +89,10 @@ export const onRequest: PagesFunction = async ({ request, next }) => {
   });
 
   if (!mdResponse.ok) {
-    // Sibling markdown missing — fall through to the HTML page.
-    return next();
+    // Sibling markdown missing (or other non-2xx) — return a markdown 404
+    // so content negotiation stays consistent for markdown-accepting
+    // clients. Browsers still hit next() via the early return above.
+    return markdownNotFound(url.pathname);
   }
 
   const text = await mdResponse.text();


### PR DESCRIPTION
Closes #125

## Summary

Adds markdown 404 responses to the content-negotiation middleware. Previously, `/docs/<slug>` requests with `Accept: text/markdown` that hit missing pages or invalid slugs fell through to the HTML 404 page — breaking content negotiation for markdown-accepting clients.

Also updates the site-planning design doc (`content-negotiation-decision.md`) to reflect the current middleware behavior and documents the new 404 response path.

## Behavior change

| Request | Before | After |
| --- | --- | --- |
| `Accept: text/markdown` on existing page | 200 markdown | 200 markdown ✓ (no change) |
| `Accept: text/markdown` on missing page | 404 HTML | **404 markdown** ✓ |
| `Accept: text/markdown` on invalid slug | 404 HTML | **404 markdown** ✓ |
| `Accept: text/html` (browsers) | 404 HTML | 404 HTML ✓ (no change) |

## Files changed

- `site/functions/_middleware.ts` — add `markdownNotFound` helper, call it from both failure paths
- `site-planning/content-negotiation-decision.md` — refresh the implementation snippet, add URL mapping table, add Error responses subsection, fix the misleading consequence text

## Test plan

- [ ] After deploy: `curl -i -H "Accept: text/markdown" https://claude-almanac.sivura.com/docs/nonexistent` returns 404 with `Content-Type: text/markdown` and recovery links in body
- [ ] After deploy: `curl -i -H "Accept: text/markdown" https://claude-almanac.sivura.com/docs/hooks` still returns 200 markdown
- [ ] After deploy: `curl -I https://claude-almanac.sivura.com/docs/nonexistent` (no Accept header) still returns HTML 404