### PR TITLE
feat(site): advertise Accept: text/markdown support in llms.txt

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "next build",
+    "postbuild": "node scripts/patch-llms-txt.mjs",
     "dev": "next dev",
     "prebuild": "node scripts/copy-images.mjs && node scripts/recent-updates.mjs && node scripts/generate-home-markdown.mjs",
     "predev": "node scripts/copy-images.mjs && node scripts/recent-updates.mjs && node scripts/generate-home-markdown.mjs",

--- a/site/scripts/patch-llms-txt.mjs
+++ b/site/scripts/patch-llms-txt.mjs
@@ -1,0 +1,73 @@
+// Post-build patch: insert an "Agent access" section into site/out/llms.txt.
+//
+// Fumadocs' llms.txt generator creates an index of pages but has no hook
+// for adding custom sections. Until Fumadocs exposes a configuration API
+// for custom content, this script patches the output at build time.
+//
+// Runs as the `postbuild` script in site/package.json — after `next build`
+// writes the static export to site/out/.
+//
+// Idempotent: skips insertion if the section already exists.
+
+import { access, readFile, writeFile } from 'node:fs/promises';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const siteDir = resolve(scriptDir, '..');
+const llmsTxtPath = resolve(siteDir, 'out/llms.txt');
+
+const SECTION_HEADING = '## Agent access';
+const SECTION = `${SECTION_HEADING}
+
+- Any URL on this site responds to \`Accept: text/markdown\` with markdown
+- Raw markdown per page at \`/llms.mdx/docs/<slug>/content.md\`
+- Full content concatenated: [/llms-full.txt](/llms-full.txt)
+- 404 responses also honor \`Accept: text/markdown\`
+`;
+
+async function main() {
+  try {
+    await access(llmsTxtPath);
+  } catch {
+    console.warn(
+      `[patch-llms-txt] ${llmsTxtPath} not found; skipping (did next build run?)`,
+    );
+    return;
+  }
+
+  const content = await readFile(llmsTxtPath, 'utf8');
+  if (content.includes(SECTION_HEADING)) {
+    console.log(`[patch-llms-txt] section already present; no change`);
+    return;
+  }
+
+  const lines = content.split('\n');
+
+  // Insert after the H1 / description but before the first content entry
+  // (either a `## ` section or a `- ` list item). Fumadocs generates a
+  // flat list with no ## sections, so the list-item heuristic is primary.
+  // If neither exists, append at the end.
+  let insertAt = lines.findIndex(
+    (line) => /^##\s/.test(line) || /^-\s/.test(line),
+  );
+  if (insertAt === -1) insertAt = lines.length;
+
+  const sectionLines = SECTION.split('\n');
+  // Ensure blank lines bracketing the inserted section.
+  const prefix =
+    insertAt > 0 && lines[insertAt - 1] !== '' ? [''] : [];
+  const suffix = [''];
+
+  lines.splice(insertAt, 0, ...prefix, ...sectionLines, ...suffix);
+
+  await writeFile(llmsTxtPath, lines.join('\n'), 'utf8');
+  console.log(
+    `[patch-llms-txt] inserted "${SECTION_HEADING}" section into out/llms.txt`,
+  );
+}
+
+main().catch((err) => {
+  console.error('[patch-llms-txt] failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Post-build script inserts an \"Agent access\" section into the generated \`llms.txt\` so agents learn about the site's content-negotiation capabilities from the canonical entry point.

## Why

llms.txt is where LLM agents discover the site. Telling them right there that any URL supports \`Accept: text/markdown\` means they don't have to trial-and-error to find the markdown access path.

## What gets inserted

Near the top of \`site/out/llms.txt\`, after the \`# Docs\` title:

\`\`\`markdown
## Agent access

- Any URL on this site responds to \`Accept: text/markdown\` with markdown
- Raw markdown per page at \`/llms.mdx/docs/<slug>/content.md\`
- Full content concatenated: [/llms-full.txt](/llms-full.txt)
- 404 responses also honor \`Accept: text/markdown\`
\`\`\`

## How

\`site/scripts/patch-llms-txt.mjs\` runs as the \`postbuild\` script after \`next build\`. Reads \`site/out/llms.txt\`, inserts the section before the first content entry (\`##\` heading or \`-\` list item), writes back.

Idempotent — skips if the section heading already exists.

## Why a post-build patch vs config

Fumadocs' llms.txt integration has no documented hook for custom content. A feature request to upstream is in progress. When Fumadocs exposes a config option, we can migrate from this post-build patch.

## Test plan

- [x] \`npm run build\` → llms.txt contains the Agent access section near the top
- [x] Script is idempotent (second run is a no-op)
- [ ] After deploy: \`curl https://claude-almanac.sivura.com/llms.txt | head -10\` shows the new section