### PR TITLE
feat(site): add Cloudflare Web Analytics beacon

### DIFF
--- a/site/public/_headers
+++ b/site/public/_headers
@@ -4,7 +4,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: geolocation=(), microphone=(), camera=()
   Strict-Transport-Security: max-age=31536000; includeSubDomains
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' static.cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
 
 /llms.txt
   Access-Control-Allow-Origin: *

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import { Inter, JetBrains_Mono } from 'next/font/google';
+import Script from 'next/script';
 import { Provider } from '@/components/provider';
 import './global.css';
 
@@ -23,6 +24,12 @@ export default function Layout({ children }: LayoutProps<'/'>) {
     >
       <body className="flex flex-col min-h-screen font-sans">
         <Provider>{children}</Provider>
+        {/* Replace PLACEHOLDER_TOKEN after enabling CF Web Analytics in the dashboard */}
+        <Script
+          src="https://static.cloudflareinsights.com/beacon.min.js"
+          data-cf-beacon='{"token":"PLACEHOLDER_TOKEN"}'
+          strategy="afterInteractive"
+        />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary

- Add Cloudflare Web Analytics beacon script to `site/src/app/layout.tsx` using `next/script` with `afterInteractive` strategy
- Update CSP in `site/public/_headers` to allow `static.cloudflareinsights.com` in `script-src` and `connect-src`
- Uses `PLACEHOLDER_TOKEN` — real token must be set after enabling Web Analytics in the CF dashboard

Closes #132

## Post-merge: enable Web Analytics

After merging, the site owner needs to:

1. Go to the [Cloudflare dashboard](https://dash.cloudflare.com)
2. Select the **claude-almanac** Pages project
3. Navigate to **Web Analytics** → **Enable**
4. Copy the beacon token
5. Replace `PLACEHOLDER_TOKEN` in `site/src/app/layout.tsx` with the real token
6. Commit and push the token update

## Test plan

- [x] `npm run build` succeeds with the new Script import
- [ ] After token replacement, verify beacon loads in browser DevTools (Network tab → `beacon.min.js`)
- [ ] Verify analytics data appears in CF dashboard within ~24h