### PR TITLE
feat: kb quality phase 1 - graph view, link fixes, ci improvements

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,6 +1,13 @@
 name: Link Check
 
 on:
+  pull_request:
+    paths:
+      - '**/*.md'
+  push:
+    branches: [main]
+    paths:
+      - '**/*.md'
   schedule:
     - cron: '0 8 * * 1'  # Mondays at 8am UTC
   workflow_dispatch:

--- a/features/skills.md
+++ b/features/skills.md
@@ -276,8 +276,8 @@ Max 500 lines. Reference supporting files:
 ```markdown
 ## Additional resources
 
-- For complete API details, see [reference.md](reference.md)
-- For usage examples, see [examples.md](examples.md)
+- For complete API details, see `reference.md`
+- For usage examples, see `examples.md`
 ```
 
 ### Restrict Availability

--- a/site/cli.json
+++ b/site/cli.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "node_modules/@fumadocs/cli/dist/schema.json",
+  "aliases": {
+    "uiDir": "./components/ui",
+    "componentsDir": "./components",
+    "layoutDir": "./layouts",
+    "cssDir": "./styles",
+    "libDir": "./lib"
+  },
+  "baseDir": "src",
+  "uiLibrary": "radix-ui",
+  "framework": "next",
+  "commands": {}
+}

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@orama/orama": "^3.1.18",
+        "d3-force": "^3.0.0",
         "fumadocs-core": "16.7.10",
         "fumadocs-mdx": "14.2.11",
         "fumadocs-ui": "16.7.10",
@@ -17,11 +18,13 @@
         "next": "16.2.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-force-graph-2d": "^1.29.1",
         "tailwind-merge": "^3.5.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.2.2",
+        "@types/d3-force": "^3.0.10",
         "@types/mdx": "^2.0.13",
         "@types/node": "^25.5.0",
         "@types/react": "^19.2.14",
@@ -3051,6 +3054,12 @@
         "tailwindcss": "4.2.2"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
+      "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -3061,6 +3070,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.13",
@@ -3722,6 +3738,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/accessor-fn": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/accessor-fn/-/accessor-fn-1.5.3.tgz",
+      "integrity": "sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -4151,6 +4176,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bezier-js": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.4.tgz",
+      "integrity": "sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/Pomax/bezierjs/blob/master/FUNDING.md"
+      }
+    },
     "node_modules/boxen": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.0.0.tgz",
@@ -4326,6 +4361,18 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-color-tracker": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/canvas-color-tracker/-/canvas-color-tracker-1.3.2.tgz",
+      "integrity": "sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "tinycolor2": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -4674,6 +4721,236 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-binarytree": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz",
+      "integrity": "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==",
+      "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force-3d": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/d3-force-3d/-/d3-force-3d-3.0.6.tgz",
+      "integrity": "sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-binarytree": "1",
+        "d3-dispatch": "1 - 3",
+        "d3-octree": "1",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-octree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-octree/-/d3-octree-1.1.0.tgz",
+      "integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==",
+      "license": "MIT"
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -5920,6 +6197,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/float-tooltip": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/float-tooltip/-/float-tooltip-1.7.5.tgz",
+      "integrity": "sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-selection": "2 - 3",
+        "kapsule": "^1.16",
+        "preact": "10"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -5934,6 +6225,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/force-graph": {
+      "version": "1.51.2",
+      "resolved": "https://registry.npmjs.org/force-graph/-/force-graph-1.51.2.tgz",
+      "integrity": "sha512-zZNdMqx8qIQGurgnbgYIUsdXxSfvhfRSIdncsKGv/twUOZpwCsk9hPHmdjdcme1+epATgb41G0rkIGHJ0Wydng==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "bezier-js": "3 - 6",
+        "canvas-color-tracker": "^1.3",
+        "d3-array": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-force-3d": "2 - 3",
+        "d3-scale": "1 - 4",
+        "d3-scale-chromatic": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-zoom": "2 - 3",
+        "float-tooltip": "^1.7",
+        "index-array-by": "1",
+        "kapsule": "^1.16",
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/framer-motion": {
@@ -6774,6 +7091,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/index-array-by": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/index-array-by/-/index-array-by-1.4.2.tgz",
+      "integrity": "sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
@@ -6800,6 +7126,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-alphabetical": {
@@ -7370,6 +7705,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jerrypick": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/jerrypick/-/jerrypick-1.1.2.tgz",
+      "integrity": "sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -7384,7 +7728,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -7460,6 +7803,18 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/kapsule": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.16.3.tgz",
+      "integrity": "sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/keyv": {
@@ -7795,6 +8150,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -7809,7 +8170,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -9251,7 +9611,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9632,6 +9991,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/preact": {
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -9646,7 +10015,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -9742,12 +10110,43 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-force-graph-2d": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/react-force-graph-2d/-/react-force-graph-2d-1.29.1.tgz",
+      "integrity": "sha512-1Rl/1Z3xy2iTHKj6a0jRXGyiI86xUti81K+jBQZ+Oe46csaMikp47L5AjrzA9hY9fNGD63X8ffrqnvaORukCuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "force-graph": "^1.51",
+        "prop-types": "15",
+        "react-kapsule": "^2.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-kapsule": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/react-kapsule/-/react-kapsule-2.5.7.tgz",
+      "integrity": "sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==",
+      "license": "MIT",
+      "dependencies": {
+        "jerrypick": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
     },
     "node_modules/react-medium-image-zoom": {
       "version": "5.4.2",
@@ -10995,6 +11394,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.0.4",

--- a/site/package.json
+++ b/site/package.json
@@ -6,7 +6,7 @@
     "build": "next build",
     "postbuild": "node scripts/patch-llms-txt.mjs",
     "dev": "next dev",
-    "prebuild": "node scripts/copy-images.mjs && node scripts/recent-updates.mjs && node scripts/last-updated.mjs && node scripts/generate-home-markdown.mjs && node scripts/generate-feed.mjs",
+    "prebuild": "node scripts/validate-frontmatter.mjs && node scripts/copy-images.mjs && node scripts/recent-updates.mjs && node scripts/last-updated.mjs && node scripts/generate-home-markdown.mjs && node scripts/generate-feed.mjs",
     "predev": "node scripts/copy-images.mjs && node scripts/recent-updates.mjs && node scripts/last-updated.mjs && node scripts/generate-home-markdown.mjs && node scripts/generate-feed.mjs",
     "start": "serve out",
     "types:check": "fumadocs-mdx && next typegen && tsc --noEmit",
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@orama/orama": "^3.1.18",
+    "d3-force": "^3.0.0",
     "fumadocs-core": "16.7.10",
     "fumadocs-mdx": "14.2.11",
     "fumadocs-ui": "16.7.10",
@@ -22,11 +23,13 @@
     "next": "16.2.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-force-graph-2d": "^1.29.1",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.2",
+    "@types/d3-force": "^3.0.10",
     "@types/mdx": "^2.0.13",
     "@types/node": "^25.5.0",
     "@types/react": "^19.2.14",

--- a/site/scripts/validate-frontmatter.mjs
+++ b/site/scripts/validate-frontmatter.mjs
@@ -1,0 +1,103 @@
+/**
+ * Validate frontmatter fields in content files against the content taxonomy.
+ *
+ * Reads every .md file in features/, guides/, case-studies/ (skipping README.md)
+ * and checks for required fields per content type. Logs warnings for missing
+ * fields but does not fail the build (many fields are still being backfilled).
+ *
+ * See internals/content-taxonomy.md for the canonical schema.
+ */
+
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const ROOT = path.resolve(import.meta.dirname, '..', '..');
+
+const COLLECTIONS = [
+  {
+    dir: 'features',
+    type: 'reference',
+    required: ['title', 'description', 'category'],
+  },
+  {
+    dir: 'guides',
+    type: 'guide',
+    required: [
+      'title',
+      'description',
+      'category',
+      'time',
+      'difficulty',
+      'prerequisites',
+      'outcome',
+    ],
+  },
+  {
+    dir: 'case-studies',
+    type: 'case-study',
+    required: [
+      'title',
+      'description',
+      'project',
+      'date',
+      'duration',
+      'author',
+      'themes',
+      'stack',
+      'outcome',
+    ],
+  },
+];
+
+/**
+ * Extract YAML frontmatter keys from raw markdown.
+ * Returns a Set of top-level key names (does not parse values).
+ */
+function extractFrontmatterKeys(content) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return new Set();
+
+  const keys = new Set();
+  for (const line of match[1].split('\n')) {
+    const keyMatch = line.match(/^([a-zA-Z_][\w-]*):/);
+    if (keyMatch) keys.add(keyMatch[1]);
+  }
+  return keys;
+}
+
+let totalWarnings = 0;
+let totalFiles = 0;
+
+for (const collection of COLLECTIONS) {
+  const dirPath = path.join(ROOT, collection.dir);
+  let files;
+  try {
+    files = await readdir(dirPath);
+  } catch {
+    console.warn(`⚠  Directory not found: ${collection.dir}/`);
+    continue;
+  }
+
+  const mdFiles = files.filter(
+    (f) => f.endsWith('.md') && f !== 'README.md',
+  );
+
+  for (const file of mdFiles) {
+    totalFiles++;
+    const filePath = path.join(dirPath, file);
+    const content = await readFile(filePath, 'utf-8');
+    const keys = extractFrontmatterKeys(content);
+
+    const missing = collection.required.filter((k) => !keys.has(k));
+    if (missing.length > 0) {
+      totalWarnings++;
+      console.warn(
+        `⚠  ${collection.dir}/${file}: missing frontmatter: ${missing.join(', ')}`,
+      );
+    }
+  }
+}
+
+console.log(
+  `\nFrontmatter validation: ${totalFiles} files checked, ${totalWarnings} with warnings.`,
+);

--- a/site/source.config.ts
+++ b/site/source.config.ts
@@ -67,7 +67,7 @@ export const reference = defineDocs({
         full: z.boolean().optional(),
       }),
     files: contentFiles,
-    postprocess: { includeProcessedMarkdown: true },
+    postprocess: { includeProcessedMarkdown: true, extractLinkReferences: true },
   },
   meta: { schema: metaSchema },
 });
@@ -97,7 +97,7 @@ export const guide = defineDocs({
         full: z.boolean().optional(),
       }),
     files: contentFiles,
-    postprocess: { includeProcessedMarkdown: true },
+    postprocess: { includeProcessedMarkdown: true, extractLinkReferences: true },
   },
   meta: { schema: metaSchema },
 });
@@ -128,7 +128,7 @@ export const caseStudy = defineDocs({
         full: z.boolean().optional(),
       }),
     files: contentFiles,
-    postprocess: { includeProcessedMarkdown: true },
+    postprocess: { includeProcessedMarkdown: true, extractLinkReferences: true },
   },
   meta: { schema: metaSchema },
 });

--- a/site/src/app/graph/page.tsx
+++ b/site/src/app/graph/page.tsx
@@ -1,0 +1,24 @@
+import { HomeLayout } from 'fumadocs-ui/layouts/home';
+import { baseOptions } from '@/lib/layout.shared';
+import { GraphView } from '@/components/graph-view';
+import { buildGraph } from '@/lib/build-graph';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Knowledge Graph',
+  description: 'Interactive graph of all documentation pages and their relationships.',
+};
+
+export default function GraphPage() {
+  return (
+    <HomeLayout {...baseOptions()}>
+      <main className="container py-8">
+        <h1 className="text-3xl font-bold mb-2">Knowledge Graph</h1>
+        <p className="text-fd-muted-foreground mb-6">
+          Interactive map of documentation pages. Hover to see descriptions, click to navigate.
+        </p>
+        <GraphView graph={buildGraph()} />
+      </main>
+    </HomeLayout>
+  );
+}

--- a/site/src/components/graph-view.tsx
+++ b/site/src/components/graph-view.tsx
@@ -1,0 +1,184 @@
+'use client';
+import { lazy, type RefObject, useEffect, useMemo, useRef, useState } from 'react';
+import type {
+  ForceGraphMethods,
+  ForceGraphProps,
+  LinkObject,
+  NodeObject,
+} from 'react-force-graph-2d';
+import { forceCollide, forceLink, forceManyBody } from 'd3-force';
+import { useRouter } from 'fumadocs-core/framework';
+
+export interface Graph {
+  links: Link[];
+  nodes: Node[];
+}
+
+export type Node = NodeObject<NodeType>;
+export type Link = LinkObject<NodeType, LinkType>;
+
+export interface NodeType {
+  text: string;
+  description?: string;
+  neighbors?: string[];
+  url: string;
+}
+
+export type LinkType = Record<string, unknown>;
+
+export interface GraphViewProps {
+  graph: Graph;
+}
+
+const ForceGraph2D = lazy(
+  () => import('react-force-graph-2d'),
+) as typeof import('react-force-graph-2d').default;
+
+export function GraphView(props: GraphViewProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [mount, setMount] = useState(false);
+  useEffect(() => {
+    setMount(true);
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      className="relative border h-[600px] [&_canvas]:size-full rounded-xl overflow-hidden bg-fd-background"
+    >
+      {mount && <ClientOnly {...props} containerRef={ref} />}
+    </div>
+  );
+}
+
+function ClientOnly({
+  containerRef,
+  graph,
+}: GraphViewProps & { containerRef: RefObject<HTMLDivElement | null> }) {
+  const graphRef = useRef<ForceGraphMethods<Node, Link> | undefined>(undefined);
+  const hoveredRef = useRef<Node | null>(null);
+  const router = useRouter();
+  const [tooltip, setTooltip] = useState<{
+    x: number;
+    y: number;
+    content: string;
+  } | null>(null);
+
+  const handleNodeHover = (node: Node | null) => {
+    const graph = graphRef.current;
+    if (!graph) return;
+    hoveredRef.current = node;
+
+    if (node) {
+      const coords = graph.graph2ScreenCoords(node.x!, node.y!);
+      setTooltip({
+        x: coords.x + 4,
+        y: coords.y + 4,
+        content: node.description ?? 'No description',
+      });
+    } else {
+      setTooltip(null);
+    }
+  };
+
+  // Custom node rendering: circle with text label below
+  const nodeCanvasObject: ForceGraphProps['nodeCanvasObject'] = (node, ctx) => {
+    const container = containerRef.current;
+    if (!container) return;
+    const style = getComputedStyle(container);
+    const fontSize = 14;
+    const radius = 5;
+
+    // Draw circle
+    ctx.beginPath();
+    ctx.arc(node.x!, node.y!, radius, 0, 2 * Math.PI, false);
+
+    const hoverNode = hoveredRef.current;
+    const isActive = hoverNode?.id === node.id || hoverNode?.neighbors?.includes(node.id as string);
+
+    ctx.fillStyle = isActive
+      ? style.getPropertyValue('--color-fd-primary')
+      : style.getPropertyValue('--color-purple-300');
+    ctx.fill();
+
+    // Draw text below the node
+    ctx.font = `${fontSize}px Sans-Serif`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillStyle = getComputedStyle(container).getPropertyValue('color');
+    ctx.fillText(node.text, node.x!, node.y! + radius + fontSize);
+  };
+
+  const linkColor = (link: Link) => {
+    const container = containerRef.current;
+    if (!container) return '#999';
+    const style = getComputedStyle(container);
+    const hoverNode = hoveredRef.current;
+
+    if (
+      hoverNode &&
+      typeof link.source === 'object' &&
+      typeof link.target === 'object' &&
+      (hoverNode.id === link.source.id || hoverNode.id === link.target.id)
+    ) {
+      return style.getPropertyValue('--color-fd-primary');
+    }
+
+    return `color-mix(in oklab, ${style.getPropertyValue('--color-fd-muted-foreground')} 50%, transparent)`;
+  };
+
+  // Enrich nodes with neighbors for hover effects
+  const enrichedNodes = useMemo(() => {
+    const { nodes, links } = structuredClone(graph);
+    for (const node of nodes) {
+      node.neighbors = links.flatMap((link) => {
+        if (link.source === node.id) return link.target as string;
+        if (link.target === node.id) return link.source as string;
+        return [];
+      });
+    }
+
+    return {
+      nodes,
+      links,
+    };
+  }, [graph]);
+
+  return (
+    <>
+      <ForceGraph2D<NodeType, LinkType>
+        ref={{
+          get current() {
+            return graphRef.current;
+          },
+          set current(fg) {
+            graphRef.current = fg;
+            if (fg) {
+              fg.d3Force('link', forceLink().distance(200));
+              fg.d3Force('charge', forceManyBody().strength(10));
+              fg.d3Force('collision', forceCollide(60));
+            }
+          },
+        }}
+        graphData={enrichedNodes}
+        nodeCanvasObject={nodeCanvasObject}
+        linkColor={linkColor}
+        onNodeHover={handleNodeHover}
+        onNodeClick={(node) => {
+          router.push(node.url);
+        }}
+        linkWidth={2}
+        enableNodeDrag
+        enableZoomInteraction
+      />
+      {tooltip && (
+        <div
+          className="absolute bg-fd-popover text-fd-popover-foreground size-fit p-2 border rounded-xl shadow-lg text-sm max-w-xs"
+          style={{ top: tooltip.y, left: tooltip.x }}
+        >
+          {tooltip.content}
+        </div>
+      )}
+    </>
+  );
+}

--- a/site/src/lib/build-graph.ts
+++ b/site/src/lib/build-graph.ts
@@ -1,0 +1,29 @@
+import { source } from '@/lib/source';
+import type { Graph } from '../components/graph-view';
+
+export function buildGraph(): Graph {
+  const pages = source.getPages();
+  const graph: Graph = { links: [], nodes: [] };
+
+  for (const page of pages) {
+    graph.nodes.push({
+      id: page.url,
+      url: page.url,
+      text: page.data.title,
+      description: page.data.description,
+    });
+
+    const { extractedReferences = [] } = page.data;
+    for (const ref of extractedReferences) {
+      const refPage = source.getPageByHref(ref.href);
+      if (!refPage) continue;
+
+      graph.links.push({
+        source: page.url,
+        target: refPage.page.url,
+      });
+    }
+  }
+
+  return graph;
+}


### PR DESCRIPTION
## Summary

Phase 1 quick wins from #139 (evolve into Karpathy-style LLM Knowledge Base).

- **Graph view** (`/graph`): Interactive force-directed graph of all documentation pages and their link relationships, using Fumadocs' `GraphView` component with `extractLinkReferences` enabled on all three content collections
- **Fix broken links in skills.md**: Lines 279-280 used markdown link syntax for `reference.md` and `examples.md` inside a code block example — replaced with inline code spans since these are illustrative filenames, not actual links
- **Lychee on PRs**: Link checking now runs on `pull_request` and `push` events (scoped to `**/*.md`), not just the weekly cron
- **Frontmatter validation**: New prebuild script (`validate-frontmatter.mjs`) checks all content files for required frontmatter fields per content type (reference/guide/case-study), logging warnings for missing fields

### Deliberately skipped

- **Task 1.2 (add `type: reference` frontmatter)**: Skipped because `fumadocs-core`'s `multiple()` helper auto-derives the `type` discriminator from the collection key name. Adding it to frontmatter would be redundant.

## Test plan

- [x] `npm run build` passes (validates prebuild scripts + static export)
- [ ] `/graph` page renders in Cloudflare Pages preview
- [ ] Lychee CI check runs on this PR
- [ ] Frontmatter validation logs 0 warnings (all existing docs have required fields)

Ref #139