### PR TITLE
feat(site): custom 404 page with search and recovery links

### DIFF
--- a/site/src/app/not-found.tsx
+++ b/site/src/app/not-found.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link';
+import { SearchButton } from '@/components/search-button';
+
+export default function NotFound() {
+  return (
+    <main className="flex flex-1 flex-col items-center justify-center px-4 py-24 text-center">
+      <p className="text-sm font-medium text-fd-primary">404</p>
+      <h1 className="mt-2 text-3xl font-bold tracking-tight text-fd-foreground sm:text-4xl">
+        Page not found
+      </h1>
+      <p className="mt-4 text-fd-muted-foreground">
+        The page you&apos;re looking for doesn&apos;t exist or has been moved.
+      </p>
+
+      <div className="mt-8">
+        <SearchButton />
+      </div>
+
+      <div className="mt-8 flex flex-wrap justify-center gap-4">
+        <Link
+          href="/docs"
+          className="inline-flex items-center rounded-md bg-fd-primary px-4 py-2 text-sm font-medium text-fd-primary-foreground transition-colors hover:bg-fd-primary/90"
+        >
+          Browse documentation
+        </Link>
+        <Link
+          href="/"
+          className="inline-flex items-center rounded-md border border-fd-border bg-fd-background px-4 py-2 text-sm font-medium text-fd-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
+        >
+          Go home
+        </Link>
+        <Link
+          href="/llms.txt"
+          className="inline-flex items-center rounded-md border border-fd-border bg-fd-background px-4 py-2 text-sm font-medium text-fd-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
+        >
+          View full index
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/site/src/components/search-button.tsx
+++ b/site/src/components/search-button.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useSearchContext } from 'fumadocs-ui/contexts/search';
+
+export function SearchButton() {
+  const { setOpenSearch } = useSearchContext();
+
+  return (
+    <button
+      type="button"
+      onClick={() => setOpenSearch(true)}
+      className="inline-flex items-center gap-2 rounded-md border border-fd-border bg-fd-background px-4 py-2 text-sm font-medium text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <circle cx="11" cy="11" r="8" />
+        <path d="m21 21-4.3-4.3" />
+      </svg>
+      Search documentation
+      <kbd className="pointer-events-none hidden rounded border border-fd-border bg-fd-muted px-1.5 py-0.5 font-mono text-xs text-fd-muted-foreground sm:inline-block">
+        ⌘K
+      </kbd>
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a branded 404 page (`not-found.tsx`) with "Page not found" heading, descriptive text, and recovery links (Browse documentation, Go home, View full index)
- Includes a search button that opens the existing Fumadocs Cmd+K search dialog via `useSearchContext`
- Uses existing `fd-*` design tokens for consistent styling with the site theme

Closes #131

## Test plan

- [ ] Visit a non-existent URL (e.g., `/does-not-exist`) and verify the custom 404 renders
- [ ] Click "Search documentation" button — Cmd+K search dialog should open
- [ ] Click "Browse documentation" → navigates to `/docs`
- [ ] Click "Go home" → navigates to `/`
- [ ] Click "View full index" → navigates to `/llms.txt`
- [ ] Verify page renders inside the root layout (no duplicate nav/body)