### PR TITLE
fix: correct grep pattern in retry script example

### DIFF
--- a/guides/agent-teams-setup.md
+++ b/guides/agent-teams-setup.md
@@ -114,7 +114,7 @@ for pane in $($TMUX_BIN list-panes -F '#{pane_id}' 2>/dev/null); do
         # Extract the intended command
         cmd=$(echo "$content" \
             | grep "CLAUDE_CODE_EXPERIMENTAL" \
-            | grep -o 'cd /[^ ]* && env CLAUDECODE.*' \
+            | grep -o 'cd /[^ ]* && env CLAUDE_CODE.*' \
             | head -1)
 
         if [ -n "$cmd" ]; then


### PR DESCRIPTION
## Summary

- Fix `CLAUDECODE` → `CLAUDE_CODE` in the retry script example in `guides/agent-teams-setup.md`
- Mirror of the same fix in dotfiles-claude (the actual script)

Closes #165

## Test plan

- [ ] Guide renders correctly