### PR TITLE
fix(ci): drop positional dir from pages deploy so wrangler.toml bindings apply

### DIFF
--- a/.github/workflows/site-build.yml
+++ b/.github/workflows/site-build.yml
@@ -62,4 +62,4 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: site
-          command: pages deploy out/ --project-name=claude-almanac
+          command: pages deploy --project-name=claude-almanac


### PR DESCRIPTION
## Summary

- The `/analytics` dashboard shows *"Analytics Engine dataset not initialized yet"* because `env.ANALYTICS.writeDataPoint()` in the content-negotiation middleware is a silent no-op at runtime
- Root cause: the deploy workflow runs `wrangler pages deploy out/ --project-name=claude-almanac`. Passing `out/` as a positional argument triggers the legacy upload path that ships files without reading bindings from `wrangler.toml`. So the `ANALYTICS` binding declared in `site/wrangler.toml` (added in 7fe68da5) is never applied to the deployed Functions
- Fix: drop the positional dir; `pages_build_output_dir = "out/"` in `wrangler.toml` tells wrangler where the output folder is, matching the Cloudflare-recommended setup for Pages projects that use `wrangler.toml` as the source of truth

## Evidence

Latest successful deploy log (run `24173738044`):

```
[command]/usr/local/bin/npx wrangler pages deploy out/ --project-name=claude-almanac
✨ Compiled Worker successfully
✨ Uploading Functions bundle
✨ Deployment complete!
```

No *"Your worker has access to the following bindings:"* section — which wrangler emits when it reads `wrangler.toml` bindings.

## Test plan

- [ ] CI (`Validate PR Title`, `Validate Commits`, `Check Markdown Format`, `Build Site`) passes
- [ ] After merge, the `Deploy` job log shows a bindings section mentioning `ANALYTICS: content_negotiation`
- [ ] Visit https://claude-almanac.sivura.com/ once to generate traffic
- [ ] Visit https://claude-almanac.sivura.com/analytics and confirm the "dataset not initialized" banner is gone and request counts are non-zero