### PR TITLE
fix(site): read analytics via AE SQL API instead of GraphQL

### DIFF
--- a/site/functions/analytics.ts
+++ b/site/functions/analytics.ts
@@ -33,80 +33,60 @@ type PagesFunction = (context: {
   env: Env;
 }) => Promise<Response>;
 
-interface AEGroup {
-  sum: { double1: number };
-  dimensions: { blob1: string; blob2: string };
+interface AESqlRow {
+  path: string;
+  format: string;
+  cnt: number;
 }
 
-interface AEResponse {
-  data?: {
-    viewer?: {
-      accounts?: Array<{
-        content_negotiationAdaptiveGroups?: AEGroup[];
-      }>;
-    };
-  };
-  errors?: Array<{ message: string }>;
+interface AESqlResponse {
+  data?: AESqlRow[];
+  rows?: number;
+  meta?: Array<{ name: string; type: string }>;
 }
 
-function rangeToDate(range: string): { start: string; end: string } {
-  const now = new Date();
-  const end = now.toISOString();
-  let ms: number;
-  switch (range) {
-    case '30d':
-      ms = 30 * 24 * 60 * 60 * 1000;
-      break;
-    case '7d':
-      ms = 7 * 24 * 60 * 60 * 1000;
-      break;
-    default:
-      ms = 24 * 60 * 60 * 1000;
-  }
-  const start = new Date(now.getTime() - ms).toISOString();
-  return { start, end };
-}
+type AEQueryResult =
+  | { kind: 'ok'; rows: AESqlRow[] }
+  | { kind: 'error'; message: string };
 
 async function queryAnalyticsEngine(
   apiToken: string,
   accountId: string,
   range: string,
-): Promise<AEResponse> {
-  const { start, end } = rangeToDate(range);
-  const query = `query {
-  viewer {
-    accounts(filter: { accountTag: "${accountId}" }) {
-      content_negotiationAdaptiveGroups(
-        limit: 100
-        filter: {
-          datetime_geq: "${start}"
-          datetime_leq: "${end}"
-        }
-        orderBy: [sum_double1_DESC]
-      ) {
-        sum { double1 }
-        dimensions {
-          blob1
-          blob2
-        }
-      }
-    }
-  }
-}`;
+): Promise<AEQueryResult> {
+  const intervalDays = range === '30d' ? 30 : range === '7d' ? 7 : 1;
+
+  // Analytics Engine SQL API. sum(_sample_interval) accounts for AE's
+  // automatic sampling — it gives a corrected event count estimate.
+  // See: https://developers.cloudflare.com/analytics/analytics-engine/sql-api/
+  const sql = `SELECT blob1 AS path, blob2 AS format, sum(_sample_interval) AS cnt
+FROM content_negotiation
+WHERE timestamp > NOW() - INTERVAL '${intervalDays}' DAY
+GROUP BY path, format
+ORDER BY cnt DESC
+FORMAT JSON`;
 
   const response = await fetch(
-    'https://api.cloudflare.com/client/v4/graphql',
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/analytics_engine/sql`,
     {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${apiToken}`,
-        'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ query }),
+      body: sql,
     },
   );
 
-  return response.json() as Promise<AEResponse>;
+  if (!response.ok) {
+    const text = await response.text();
+    return {
+      kind: 'error',
+      message: `HTTP ${response.status}: ${text.slice(0, 500)}`,
+    };
+  }
+
+  const body = (await response.json()) as AESqlResponse;
+  return { kind: 'ok', rows: body.data ?? [] };
 }
 
 function escapeHtml(str: string): string {
@@ -691,7 +671,7 @@ export const onRequest: PagesFunction = async ({ request, env }) => {
   const rangeParam = url.searchParams.get('range') ?? '24h';
   const range = ['24h', '7d', '30d'].includes(rangeParam) ? rangeParam : '24h';
 
-  let result: AEResponse;
+  let result: AEQueryResult;
   try {
     result = await queryAnalyticsEngine(env.CF_API_TOKEN, env.CF_ACCOUNT_ID, range);
   } catch (err) {
@@ -703,30 +683,28 @@ export const onRequest: PagesFunction = async ({ request, env }) => {
     });
   }
 
-  if (result.errors?.length) {
-    const msg = result.errors.map((e) => e.message).join('; ');
-    const isDatasetEmpty = msg.includes('unknown field');
-    const displayError = isDatasetEmpty
-      ? 'Analytics Engine dataset not initialized yet. Data will appear after traffic flows through the site with the ANALYTICS binding active.'
-      : `GraphQL error: ${msg}`;
-    const html = buildPage(range, 0, 0, new Map(), displayError);
+  if (result.kind === 'error') {
+    const html = buildPage(
+      range,
+      0,
+      0,
+      new Map(),
+      `Analytics Engine query failed: ${result.message}`,
+    );
     return new Response(html, {
       status: 200,
       headers: { 'Content-Type': 'text/html; charset=utf-8' },
     });
   }
 
-  const groups =
-    result.data?.viewer?.accounts?.[0]?.content_negotiationAdaptiveGroups ?? [];
-
   let totalMarkdown = 0;
   let totalHtml = 0;
   const pathData = new Map<string, PathStats>();
 
-  for (const group of groups) {
-    const path = group.dimensions.blob1;
-    const format = group.dimensions.blob2;
-    const count = group.sum.double1;
+  for (const row of result.rows) {
+    const path = row.path;
+    const format = row.format;
+    const count = Math.round(Number(row.cnt) || 0);
 
     if (format === 'markdown') totalMarkdown += count;
     else totalHtml += count;


### PR DESCRIPTION
## Summary

The `/analytics` dashboard is stuck on *"Analytics Engine dataset not initialized yet"* even though the `content_negotiation` dataset in the Cloudflare account already holds **21,000+ events**. Browser-based reconnaissance in the Cloudflare dashboard confirmed:

- The `ANALYTICS` → `content_negotiation` binding is correctly attached (managed via `wrangler.toml`)
- The dataset exists in `workers/analytics-engine` with recent writes (most recent: today, a few minutes after the last deploy)
- Writes from the middleware's `env.ANALYTICS.writeDataPoint()` calls are landing fine

So the write side is healthy. The bug is on the **read side**: `/analytics` was calling the wrong Cloudflare API.

### Root cause

`queryAnalyticsEngine()` was hitting `POST /client/v4/graphql` with a hand-built query that referenced a field named `content_negotiationAdaptiveGroups`. That GraphQL field naming convention is not the documented read interface for Analytics Engine datasets, and Cloudflare returns an `"unknown field"` error that the code was then mis-classifying as *"dataset not initialized yet"* (see the `isDatasetEmpty` branch added in 7fe68da5). The friendly fallback message hid the real failure.

### Fix

Replace the GraphQL call with Cloudflare's **Analytics Engine SQL API** — the documented read path:

```
POST https://api.cloudflare.com/client/v4/accounts/{account_id}/analytics_engine/sql
Authorization: Bearer <token>   # scope: Account Analytics: Read
Body: <plain SQL>
```

The new query is:

```sql
SELECT blob1 AS path, blob2 AS format, sum(_sample_interval) AS cnt
FROM content_negotiation
WHERE timestamp > NOW() - INTERVAL '1' DAY
GROUP BY path, format
ORDER BY cnt DESC
FORMAT JSON
```

`sum(_sample_interval)` is required — Analytics Engine auto-samples at ingest, so a raw `count(*)` undercounts; summing `_sample_interval` gives the sampling-corrected estimate.

The main handler is updated for the new return shape (`{ kind: 'ok', rows } | { kind: 'error', message }`). Dead GraphQL types (`AEGroup`, `AEResponse`), the `rangeToDate` helper, and the `"unknown field"` mis-classification are all removed. On failure the page now shows the real `HTTP <status>: <body>` message, so if there's a token-scope issue or a query syntax error it will be visible instead of hidden.

### Diff stat

`1 file changed, 48 insertions(+), 70 deletions(-)` — net reduction.

### No-op areas

- `ANALYTICS` binding config (already correct)
- Middleware write path (already correct)
- Token name / secrets (`CF_API_TOKEN`, `CF_ACCOUNT_ID` unchanged)
- `wrangler.toml` (unchanged)

### Follow-ups (separate PRs)

- The `DB` and `STATS_CACHE` bindings are not declared in `wrangler.toml`, so the D1 aggregate section and KV caching are currently no-ops under wrangler.toml-as-source-of-truth mode. Worth a follow-up PR to add those bindings to `site/wrangler.toml` with the real database/namespace IDs.

## Test plan

- [ ] `Validate PR Title`, `Validate Commits`, `Check Markdown Format`, `Build Site` CI checks pass
- [ ] After merge + deploy, visit https://claude-almanac.sivura.com/analytics and confirm:
  - [ ] No "dataset not initialized" banner
  - [ ] MARKDOWN REQUESTS / HTML REQUESTS cards are non-zero
  - [ ] Per-path table at bottom is populated
- [ ] If the token lacks `Account Analytics: Read`, the error surfaced will now say `HTTP 403: ...` instead of the old misleading message — easy to diagnose and resolve by scoping the token