### PR TITLE
ci: fix link check failures on main

### DIFF
--- a/features/auto-memory.md
+++ b/features/auto-memory.md
@@ -155,6 +155,6 @@ From the [Claude Code v2.1.59 changelog](https://github.com/anthropics/claude-co
 
 ## Sources
 
-- [Memory Management (Official Docs)](https://docs.anthropic.com/docs/en/memory)
-- [Claude Code Settings](https://docs.anthropic.com/docs/en/settings)
+- [Memory Management (Official Docs)](https://code.claude.com/docs/en/memory)
+- [Claude Code Settings](https://code.claude.com/docs/en/settings)
 - [Claude Code v2.1.59 Release](https://github.com/anthropics/claude-code/releases/tag/v2.1.59)

--- a/guides/agent-teams-setup.md
+++ b/guides/agent-teams-setup.md
@@ -15,7 +15,7 @@ author: Alexander Sivura
 
 # Agent Teams: Environment Setup
 
-Tools, configuration, and IDE integration for running multiple Claude Code sessions in parallel. Install these once and you're ready to use the [coordination patterns](agent-teams.md).
+Tools, configuration, and IDE integration for running multiple Claude Code sessions in parallel. Install these once and you're ready to use the [coordination patterns](../features/agent-teams.md).
 
 ## Tools Overview
 
@@ -685,7 +685,7 @@ The fix is always the same: explicitly mention `TeamCreate` and `team_name` in y
 
 ## Next Steps
 
-Your environment is ready. Head to [Agent Teams](agent-teams.md) for architecture details, display modes, hooks, and the full tool reference.
+Your environment is ready. Head to [Agent Teams](../features/agent-teams.md) for architecture details, display modes, hooks, and the full tool reference.
 
 ## Sources
 
@@ -693,4 +693,4 @@ Your environment is ready. Head to [Agent Teams](agent-teams.md) for architectur
 - [Ghostty Terminal](https://ghostty.org/)
 - [tmux](https://github.com/tmux/tmux/wiki)
 - [Starship Prompt](https://starship.rs/)
-- [Agent Teams](agent-teams.md) - Architecture, display modes, hooks, and tool reference
+- [Agent Teams](../features/agent-teams.md) - Architecture, display modes, hooks, and tool reference

--- a/guides/dotfiles-version-control.md
+++ b/guides/dotfiles-version-control.md
@@ -244,12 +244,11 @@ The setup script handles everything: backs up existing config, creates symlinks,
 
 ## Next Steps
 
-- [Settings](settings.md) -- full reference for `settings.json` options
-- [Memory & Context](memory-context.md) -- how CLAUDE.md and rules work
+- [Settings](../features/settings.md) -- full reference for `settings.json` options
+- [Memory & Context](../features/memory-context.md) -- how CLAUDE.md and rules work
 - [Multi-Project Workspace](multi-project-workspace.md) -- add a VS Code workspace and `additionalDirectories` to the repo
 - [Agent Teams Setup](agent-teams-setup.md) -- add Ghostty/tmux scripts to the repo
 
 ## Sources
 
 - [Claude Code Settings](https://code.claude.com/docs/en/settings.md)
-- [Claude Code Configuration](https://code.claude.com/docs/en/configuration.md)

--- a/guides/multi-project-workspace.md
+++ b/guides/multi-project-workspace.md
@@ -169,9 +169,9 @@ Ghostty launcher (ghostty-claude.sh)
 ## Next Steps
 
 - [Agent Teams Setup](agent-teams-setup.md) -- configure Ghostty + tmux for the launcher task
-- [Settings](settings.md) -- full reference for `additionalDirectories` and other Claude Code settings
-- [Memory & Context](memory-context.md) -- how CLAUDE.md files work across projects
-- [Rules](rules.md) -- modular rules for project-specific and global conventions
+- [Settings](../features/settings.md) -- full reference for `additionalDirectories` and other Claude Code settings
+- [Memory & Context](../features/memory-context.md) -- how CLAUDE.md files work across projects
+- [Rules](../features/rules.md) -- modular rules for project-specific and global conventions
 
 ## Sources
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,12 @@
+# Lychee link checker config. Consumed automatically by lycheeverse/lychee-action.
+# See https://github.com/lycheeverse/lychee#configuration
+
+# Exclude URLs that are not real failures:
+#   - npmjs.com returns 403 to headless bots
+#   - dash.cloudflare.com is auth-walled (always 403 without a session)
+#   - localhost references are dev-server instructions
+exclude = [
+    "^https://www\\.npmjs\\.com/",
+    "^https://dash\\.cloudflare\\.com/",
+    "^https?://localhost(:\\d+)?(/|$)",
+]

--- a/lychee.toml
+++ b/lychee.toml
@@ -4,9 +4,12 @@
 # Exclude URLs that are not real failures:
 #   - npmjs.com returns 403 to headless bots
 #   - dash.cloudflare.com is auth-walled (always 403 without a session)
+#   - claude.ai app routes (/code, /admin-settings, /analytics) are all
+#     auth-walled — checking them headless always returns 403
 #   - localhost references are dev-server instructions
 exclude = [
     "^https://www\\.npmjs\\.com/",
     "^https://dash\\.cloudflare\\.com/",
+    "^https://claude\\.ai/(code|admin-settings|analytics)(/|$)",
     "^https?://localhost(:\\d+)?(/|$)",
 ]

--- a/site/ARCHITECTURE.md
+++ b/site/ARCHITECTURE.md
@@ -68,7 +68,7 @@ Content lives in three directories, each with a distinct content type:
 
 All three feed the **same `/docs/` URL namespace** (slugs must be unique across directories). Source directory is a contributor concept; URL is a reader concept.
 
-See [content-taxonomy.md](./content-taxonomy.md) for the full spec on content types, voices, and schemas.
+See [content-taxonomy.md](../internals/content-taxonomy.md) for the full spec on content types, voices, and schemas.
 
 ### Source-to-URL mapping
 
@@ -180,7 +180,7 @@ sequenceDiagram
     MW-->>A: text/markdown response
 ```
 
-This gives us parity with Cloudflare's paid "Markdown for Agents" feature on the free tier. See [content-negotiation-decision.md](./content-negotiation-decision.md).
+This gives us parity with Cloudflare's paid "Markdown for Agents" feature on the free tier. See [content-negotiation-decision.md](../internals/content-negotiation-decision.md).
 
 ## Per-type page rendering
 
@@ -357,10 +357,10 @@ Generated automatically at build time:
 
 ## Related docs
 
-- [framework-decision.md](./framework-decision.md) — why we chose Fumadocs
-- [content-negotiation-decision.md](./content-negotiation-decision.md) — why we built our own Accept header middleware
-- [content-taxonomy.md](./content-taxonomy.md) — reference vs guide vs case study
-- [theme-claude-almanac.css](./theme-claude-almanac.css) — the exported theme
+- [framework-decision.md](../internals/framework-decision.md) — why we chose Fumadocs
+- [content-negotiation-decision.md](../internals/content-negotiation-decision.md) — why we built our own Accept header middleware
+- [content-taxonomy.md](../internals/content-taxonomy.md) — reference vs guide vs case study
+- [theme.css](./src/styles/theme.css) — the exported theme
 
 ## Open questions
 


### PR DESCRIPTION
## Summary

Fixes the Link Check workflow failures introduced on main in [run 24315004049](https://github.com/asivura/claude-almanac/actions/runs/24315004049). Link check was only added in `54e0bd4f`; that PR itself didn't touch `.md` files so its own PR run didn't trigger, and the next push to main surfaced these pre-existing issues.

### Errors addressed

**Cross-content sibling refs (6 links)** — guides/ files linked to `settings.md`, `memory-context.md`, `rules.md`, `agent-teams.md` as siblings. Those files live in `features/`. Fumadocs resolves them via the unified `/docs/<slug>` namespace at render time, but lychee checks filesystem paths literally. Rewrote as explicit `../features/...` paths (matching the existing convention in `features/additional-features.md` and `features/agent-teams.md`).

**Wrong paths in `site/ARCHITECTURE.md` (4 links)** — referenced `./content-taxonomy.md`, `./content-negotiation-decision.md`, `./framework-decision.md`, `./theme-claude-almanac.css` as if they were siblings of `site/ARCHITECTURE.md`. The decision docs live in `../internals/`; the theme lives at `./src/styles/theme.css`.

**Real 404 (1 link)** — `guides/dotfiles-version-control.md` listed `https://code.claude.com/docs/en/configuration.md` (doesn't exist). Near-duplicate of the adjacent "Claude Code Settings" entry, so removed.

**False-positive exclusions (via new `lychee.toml`)**:
- `https://www.npmjs.com/*` — returns 403 to headless bots
- `https://dash.cloudflare.com/*` — auth-walled
- `http://localhost*` — dev server instructions in `site/README.md`

## Test plan

- [ ] Link Check workflow passes on this PR
- [ ] No rendering regressions on the Cloudflare Pages preview (spot-check guides `agent-teams-setup`, `dotfiles-version-control`, `multi-project-workspace`)