### PR TITLE
docs: add teammate model configuration and resolution order

### DIFF
--- a/features/agent-teams.md
+++ b/features/agent-teams.md
@@ -334,12 +334,46 @@ Create a team to debug the memory leak. Spawn three investigators:
 - One analyzing recent deployments for regressions
 ```
 
-### Specifying Teammate Models
+### Controlling Teammate Models
+
+By default, teammates inherit the lead session's model. There are four ways to override this:
+
+**1. Custom agent definitions** — set the `model` field in `.claude/agents/<name>.md` frontmatter:
+
+```yaml
+model: sonnet        # Short alias (recommended)
+model: claude-opus-4-6  # Full model ID
+model: inherit       # Same as lead session (default)
+```
+
+**2. Natural language** — specify the model when spawning:
 
 ```
 Create a team with 4 teammates to refactor these modules in parallel.
 Use Sonnet for each teammate.
 ```
+
+**3. CLAUDE.md guidance** — add model instructions so the lead applies them consistently:
+
+```markdown
+When spawning Agent Teams teammates, always pass `model: "sonnet"`
+on the Agent tool call unless a specific model is requested.
+```
+
+**4. Environment variable** — `CLAUDE_CODE_SUBAGENT_MODEL` overrides all other settings:
+
+```bash
+export CLAUDE_CODE_SUBAGENT_MODEL=sonnet
+```
+
+**Model resolution order** (highest priority first):
+
+1. `CLAUDE_CODE_SUBAGENT_MODEL` environment variable
+1. Per-invocation `model` parameter on the Agent tool call
+1. Agent definition's `model` frontmatter
+1. Lead session's model (inheritance)
+
+Short aliases (`sonnet`, `opus`, `haiku`) resolve to the latest version automatically and work in all contexts. Full model IDs (e.g., `claude-opus-4-6`) are supported in agent definition frontmatter but may cause errors when passed as per-invocation parameters.
 
 ## Best Practices
 

--- a/features/agents.md
+++ b/features/agents.md
@@ -167,8 +167,16 @@ When invoked:
 model: sonnet        # High capability
 model: opus          # Maximum capability
 model: haiku         # Fast and cheap
-model: inherit       # Same as parent
+model: claude-opus-4-6  # Full model ID
+model: inherit       # Same as parent (default)
 ```
+
+When a subagent is invoked, the model is resolved in this order (highest priority first):
+
+1. `CLAUDE_CODE_SUBAGENT_MODEL` environment variable
+1. Per-invocation `model` parameter on the Agent tool call
+1. Agent definition's `model` frontmatter
+1. Parent session's model (inheritance)
 
 ### Using Hooks with Agents
 


### PR DESCRIPTION
## Summary

- Expanded the "Specifying Teammate Models" section in `features/agent-teams.md` into a comprehensive "Controlling Teammate Models" section covering all 4 ways to set the model (agent definitions, natural language, CLAUDE.md guidance, env var) and the model resolution order
- Added model resolution order and full model ID example to `features/agents.md` Model Configuration section

Based on a question from a team member who hit "Invalid model name" errors when using full model IDs as per-invocation parameters.

## Test plan

- [ ] Verify markdown renders correctly on the site
- [ ] Confirm no broken links