### PR TITLE
fix: describe dev containers as Docker containers, not VMs

### DIFF
--- a/features/security-sandbox.md
+++ b/features/security-sandbox.md
@@ -347,7 +347,7 @@ The sandbox isolates Bash subprocesses. Other tools have different boundaries:
 
 ### Security Benefits
 
-- Isolated Docker container per project, providing a consistent environment across the team
+- Isolated Docker container per project
 - Custom firewall restricting network
 - Enhanced isolation for `--dangerously-skip-permissions`
 - Default-deny network policy

--- a/features/security-sandbox.md
+++ b/features/security-sandbox.md
@@ -347,7 +347,7 @@ The sandbox isolates Bash subprocesses. Other tools have different boundaries:
 
 ### Security Benefits
 
-- Isolated virtual machines per session
+- Isolated Docker container per project, providing a consistent environment across the team
 - Custom firewall restricting network
 - Enhanced isolation for `--dangerously-skip-permissions`
 - Default-deny network policy


### PR DESCRIPTION
## Summary
- Fix `features/security-sandbox.md` Development Containers section to describe dev containers as Docker-based, not VMs
- Aligns with the canonical .devcontainer spec and with PR #185's `ssh-connections.md` description

## Test plan
- [ ] CI: Validate PR Title / Validate Commits / Check Markdown Format
- [ ] Cloudflare Pages auto-deploys after merge

Closes #187