### PR TITLE
docs: phase-2 standardize "Remote" naming for VM environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Comprehensive documentation of Claude Code's extensibility features and capabili
 | [GitLab CI/CD](./features/gitlab-cicd.md)                    | GitLab pipelines       | MR automation, @claude mentions, Bedrock/Vertex auth        |
 | [Voice Dictation](./features/voice-dictation.md)             | Speech input           | Speak prompts instead of typing, coding vocabulary          |
 | [Computer Use](./features/computer-use.md)                   | GUI automation         | Native app testing, visual debugging, simulator control     |
-| [Ultraplan](./features/ultraplan.md)                         | Cloud planning         | Draft plans on the web, review in browser, execute anywhere |
+| [Ultraplan](./features/ultraplan.md)                         | Remote planning        | Draft plans on the web, review in browser, execute anywhere |
 | [Additional Features](./features/additional-features.md)     | Advanced capabilities  | Git worktrees, images, sessions, plan mode                  |
 
 ______________________________________________________________________
@@ -743,7 +743,7 @@ ______________________________________________________________________
 
 ### Ultraplan
 
-**Purpose**: Draft plans in the cloud, review in your browser, execute anywhere.
+**Purpose**: Draft plans on Remote, review in your browser, execute anywhere.
 
 **Key Capabilities**:
 
@@ -886,7 +886,7 @@ ______________________________________________________________________
 1. **Using GitLab?** → Set up [GitLab CI/CD](./features/gitlab-cicd.md) for MR automation
 1. **Prefer voice?** → Enable [Voice Dictation](./features/voice-dictation.md) for speech input
 1. **Testing native apps?** → Use [Computer Use](./features/computer-use.md) for GUI automation
-1. **Complex planning?** → Try [Ultraplan](./features/ultraplan.md) for cloud-based plan drafting
+1. **Complex planning?** → Try [Ultraplan](./features/ultraplan.md) for plan drafting on Remote
 1. **Advanced features?** → Explore [Additional Features](./features/additional-features.md)
 
 ______________________________________________________________________

--- a/features/additional-features.md
+++ b/features/additional-features.md
@@ -313,7 +313,7 @@ Native desktop app with GUI.
 
 - Multiple isolated coding sessions
 - Built-in Git worktree support
-- Launch local or cloud sessions
+- Launch Local or Remote sessions
 - Browser control integration
 
 [Documentation](https://code.claude.com/docs/en/desktop)

--- a/features/channels.md
+++ b/features/channels.md
@@ -302,7 +302,7 @@ When set, this replaces the Anthropic allowlist entirely. An empty array blocks 
 
 | Feature                | What It Does                                           | Good For                                          |
 | ---------------------- | ------------------------------------------------------ | ------------------------------------------------- |
-| **Claude Code on web** | Fresh cloud sandbox cloned from GitHub                 | Delegating self-contained async work              |
+| **Claude Code on web** | Fresh Remote sandbox cloned from GitHub                | Delegating self-contained async work              |
 | **Claude in Slack**    | Spawns web session from `@Claude` mention              | Starting tasks from team conversation context     |
 | **Standard MCP**       | Claude queries on demand; nothing pushed               | Giving Claude read/query access to a system       |
 | **Remote Control**     | Drive local session from claude.ai or mobile app       | Steering in-progress session while away from desk |

--- a/features/ssh-connections.md
+++ b/features/ssh-connections.md
@@ -173,7 +173,7 @@ If you need to drive a long-running terminal session from a phone, use Remote Co
 - **Linux clients cannot use this feature**, since the desktop app is not available on Linux. CLI users on Linux can still `ssh` to a remote host and run `claude` there.
 - **No integrated terminal pane in SSH sessions.** Use a separate terminal with `ssh` for shell access on the remote host.
 - **No "Continue in → Claude Code on the Web"** for SSH sessions. That handoff is available for local sessions only and requires a clean working tree.
-- **`@mention` and the file pane** are available in local and SSH sessions, but not in cloud Remote sessions.
+- **`@mention` and the file pane** are available in local and SSH sessions, but not in Remote sessions.
 - **`sshHostAllowlist` only applies to the desktop app.** It does not restrict the CLI, IDE extensions, or `ssh` calls from Claude's Bash tool.
 
 ## Sources

--- a/features/ssh-connections.md
+++ b/features/ssh-connections.md
@@ -13,11 +13,11 @@ SSH connections let you run Claude Code on a remote Linux or macOS machine while
 
 SSH is one of three environments you can pick when starting a session in the desktop app's **Code** tab, alongside **Local** and **Remote**:
 
-| Environment | Where Claude runs               | Where files live         |
-| ----------- | ------------------------------- | ------------------------ |
-| Local       | Your machine                    | Your machine             |
-| Remote      | Anthropic-managed cloud VM      | Cloned into the cloud VM |
-| SSH         | A remote machine you connect to | The remote machine       |
+| Environment | Where Claude runs               | Where files live   |
+| ----------- | ------------------------------- | ------------------ |
+| Local       | Your machine                    | Your machine       |
+| Remote      | Anthropic-managed VM            | Cloned into the VM |
+| SSH         | A remote machine you connect to | The remote machine |
 
 When you select an SSH connection, the desktop app opens an SSH session to the host, installs Claude Code on the remote machine the first time you connect, and starts a session that runs entirely on that host. Your prompts, diffs, and approvals flow through the SSH connection back to the desktop UI.
 

--- a/features/ultraplan.md
+++ b/features/ultraplan.md
@@ -1,6 +1,6 @@
 ---
 title: Ultraplan
-description: Draft a plan on the web in plan mode, then execute it in the cloud or send it back to the terminal.
+description: Draft a plan on the web in plan mode, then execute it on Remote or send it back to the terminal.
 category: workflows
 ---
 
@@ -8,7 +8,7 @@ category: workflows
 
 > **Status**: Research preview. Requires a Claude Code on the web account and a GitHub repository.
 
-Start a plan from your local CLI, draft and review it on Claude Code on the web in plan mode, then execute it in the cloud or send it back to your terminal.
+Start a plan from your local CLI, draft and review it on Claude Code on the web in plan mode, then execute it on Remote or send it back to your terminal.
 
 ## Why Ultraplan
 
@@ -22,7 +22,7 @@ Ultraplan is useful when the terminal isn't enough for plan review:
 
 - Claude Code on the web account
 - GitHub repository
-- The cloud session runs in your account's default cloud environment
+- The Remote session runs in your account's default Remote environment
 
 ## Launch Ultraplan
 
@@ -54,7 +54,7 @@ After launch, your CLI prompt shows a status indicator while the remote session 
 | `ultraplan needs your input` | Claude has a clarifying question; open the session link to respond |
 | `ultraplan ready`            | The plan is ready to review in your browser                        |
 
-Run `/tasks` and select the ultraplan entry to open a detail view with the session link, agent activity, and a **Stop ultraplan** action. Stopping archives the cloud session and clears the indicator.
+Run `/tasks` and select the ultraplan entry to open a detail view with the session link, agent activity, and a **Stop ultraplan** action. Stopping archives the Remote session and clears the indicator.
 
 ## Review and Revise
 
@@ -72,7 +72,7 @@ When the plan looks right, choose from the browser:
 
 ### Execute on the Web
 
-Select **Approve Claude's plan and start coding** in your browser. Claude implements the plan in the same cloud session. Your terminal shows a confirmation, the status indicator clears, and work continues in the cloud. When finished, review the diff and create a PR from the web interface.
+Select **Approve Claude's plan and start coding** in your browser. Claude implements the plan in the same Remote session. Your terminal shows a confirmation, the status indicator clears, and work continues on Remote. When finished, review the diff and create a PR from the web interface.
 
 ### Send Back to Terminal
 


### PR DESCRIPTION
## Summary

Continues #189's standardization of "Cloud" to "Remote" for the Anthropic-managed VM environment. Four files renamed, two investigated and excluded with reasons.

- `features/channels.md` L305: "Fresh cloud sandbox" to "Fresh Remote sandbox" in the comparison table.
- `features/ultraplan.md`: six occurrences renamed across the frontmatter description, intro prose, requirements bullet, status section, and "Execute on the Web" section. Idiom matches PR #189: "execute on Remote", "Remote session", "Remote environment".
- `features/additional-features.md` L316: "Launch local or cloud sessions" to "Launch Local or Remote sessions" in the Desktop Preview section, matching the Local/Remote/SSH triplet from `ide-integrations.md`.
- `features/ssh-connections.md` L176: editorial trim, "cloud Remote sessions" to "Remote sessions" (doubled qualifier was awkward).

## Investigated and excluded

- `features/scheduled-tasks.md`: Anthropic's canonical doc at https://code.claude.com/docs/en/scheduled-tasks still uses "Cloud" as a column descriptor in the same scheduling-options comparison table our doc mirrors. The Anthropic-managed product itself has been rebranded to **Routines** (see https://code.claude.com/docs/en/routines, which `web-scheduled-tasks` redirects to), not "Remote Scheduled Tasks". Renaming our column to "Remote" would diverge from upstream, and renaming the section to "Remote Scheduled Tasks" would invent terminology Anthropic does not use. Tracked separately as a potential rebrand-to-Routines pass.
- `features/security-sandbox.md` L63: the `### Cloud Environment` heading is a pre-existing labeling error rather than a Cloud-to-Remote rename candidate. The three bullets below it (Limited / Disabled / Full) describe Network Access Levels, not the VM environment. The correct fix is renaming the heading to match its content (e.g. `### Network Access Levels`), which is a different scope from this PR.

## Out of scope (deliberately not changed)

- `features/scheduled-tasks.md`: see Investigated and excluded above. Needs a separate PR (likely a rename to align with Anthropic's "Routines" product label).
- `features/security-sandbox.md` L63: needs a heading-correctness fix, not a Cloud-to-Remote rename. Separate follow-up.

## Test plan

- [ ] CI: Validate PR Title / Validate Commits / Check Markdown Format pass
- [ ] Cloudflare Pages auto-deploys after merge

References #190