### PR TITLE
fix: rename mislabeled `### Cloud Environment` heading in security-sandbox.md

### DIFF
--- a/features/security-sandbox.md
+++ b/features/security-sandbox.md
@@ -60,7 +60,7 @@ Network access is controlled through a proxy server running outside the sandbox.
 ![Git Integration Proxy](../resources/images/git-integration-proxy.png)
 *Source: [Beyond permission prompts: making Claude Code more secure and autonomous](https://www.anthropic.com/engineering/claude-code-sandboxing)*
 
-### Cloud Environment
+### Network Access Levels
 
 Three access levels:
 


### PR DESCRIPTION
## Summary

- Rename `### Cloud Environment` to `### Network Access Levels` in `features/security-sandbox.md`. The heading was a pre-existing labeling bug, the bullets below it (Limited / Disabled / Full) describe network access levels, not the Anthropic-managed VM environment.

## Anchor change

- Old slug: `cloud-environment` -> new slug: `network-access-levels`
- Inbound references found: none (grep across `*.md` excluding `site/` returned no matches)

## Test plan

- [ ] CI: Validate PR Title / Validate Commits / Check Markdown Format pass
- [ ] Cloudflare Pages auto-deploys after merge

Closes #193