### PR TITLE
docs: rebrand cloud scheduled-tasks to "Routines"

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Comprehensive documentation of Claude Code's extensibility features and capabili
 | [Security & Sandbox](./features/security-sandbox.md)         | Isolation and controls | Secure execution, network isolation, enterprise policies    |
 | [Testing](./features/testing.md)                             | Config validation      | Validate settings, skills, schemas in CI/CD                 |
 | [Plans & Pricing](./features/pricing.md)                     | Plan comparison        | Pricing, Claude Code access, feature matrix by plan         |
-| [Scheduled Tasks](./features/scheduled-tasks.md)             | Recurring automation   | Cloud cron jobs, desktop tasks, CLI loops                   |
+| [Scheduled Tasks](./features/scheduled-tasks.md)             | Recurring automation   | Routines (cloud), desktop tasks, CLI loops                  |
 | [Checkpointing](./features/checkpointing.md)                 | Session recovery       | Undo changes, rewind to previous states, explore safely     |
 | [Code Review](./features/code-review.md)                     | Automated PR review    | Multi-agent analysis for bugs, security, regressions        |
 | [Channels](./features/channels.md)                           | Persistent AI threads  | Long-running projects, recurring workflows, team context    |
@@ -577,7 +577,7 @@ ______________________________________________________________________
 
 **Key Capabilities**:
 
-- Cloud tasks (cron) via claude.ai for Team/Enterprise
+- Routines via claude.ai (cloud, schedule/API/GitHub triggers, Pro and above)
 - Desktop tasks via the macOS/Windows app
 - CLI `/loop` command for repeating local tasks
 - CronCreate/CronList/CronDelete tools for programmatic scheduling

--- a/features/scheduled-tasks.md
+++ b/features/scheduled-tasks.md
@@ -1,6 +1,6 @@
 ---
 title: Scheduled Tasks
-description: 'Three ways to schedule recurring Claude Code work: cloud, desktop app, and the /loop CLI command.'
+description: 'Three ways to schedule recurring Claude Code work: Routines (cloud), desktop app, and the /loop CLI command.'
 category: ci-cd
 ---
 
@@ -10,7 +10,7 @@ Claude Code offers three ways to schedule recurring work, each suited to differe
 
 ## Scheduling Options Comparison
 
-|                            | Cloud                          | Desktop                     | `/loop` (CLI)         |
+|                            | Routines (cloud)               | Desktop                     | `/loop` (CLI)         |
 | -------------------------- | ------------------------------ | --------------------------- | --------------------- |
 | Runs on                    | Anthropic cloud                | Your machine                | Your machine          |
 | Requires machine on        | No                             | Yes                         | Yes                   |
@@ -24,43 +24,55 @@ Claude Code offers three ways to schedule recurring work, each suited to differe
 
 **When to use which:**
 
-- **Cloud tasks**: Work that should run reliably without your machine (daily PR reviews, overnight CI analysis)
+- **Routines**: Work that should run reliably without your machine (daily PR reviews, overnight CI analysis), or that needs to react to API calls or GitHub events
 - **Desktop tasks**: Need access to local files and tools (code reviews against your working directory)
 - **`/loop`**: Quick polling during a session (watching a deployment, babysitting a PR)
 
-## Cloud Scheduled Tasks
+## Routines (Cloud)
 
-Cloud scheduled tasks run on Anthropic-managed infrastructure. They keep working even when your computer is off.
+Routines run on Anthropic-managed infrastructure. They keep working even when your computer is off. A routine is a saved Claude Code configuration (prompt, repositories, connectors, environment) packaged once and run automatically by one or more triggers.
+
+> Anthropic rebranded this product from "Cloud Scheduled Tasks" to **Routines** in 2026. The old `web-scheduled-tasks` doc URL now redirects to `/en/routines`. Routines are in research preview, so behavior, limits, and the API surface may change.
 
 ### Availability
 
-Pro, Max, Team, and Enterprise users.
+Pro, Max, Team, and Enterprise users with [Claude Code on the web](https://code.claude.com/docs/en/claude-code-on-the-web) enabled. Team and Enterprise admins can disable routines org-wide via the **Routines** toggle in admin settings.
 
-### Creating Cloud Tasks
+### Trigger Types
 
-Create from three places:
+A routine can have one or more triggers attached. Multiple triggers can be combined on a single routine.
 
-- **Web**: Visit [claude.ai/code/scheduled](https://claude.ai/code/scheduled) and click **New scheduled task**
-- **Desktop**: Open the **Schedule** page, click **New task**, choose **New remote task**
-- **CLI**: Run `/schedule` in any session. Claude walks through setup conversationally. You can also pass a description: `/schedule daily PR review at 9am`
+| Trigger      | Fires when                                                                   |
+| ------------ | ---------------------------------------------------------------------------- |
+| **Schedule** | Recurring cadence (hourly, daily, weekdays, weekly) or once at a future time |
+| **API**      | An authenticated POST to a per-routine `/fire` endpoint                      |
+| **GitHub**   | A matching repository event (pull request or release actions)                |
+
+### Creating a Routine
+
+Create from three places. All three surfaces write to the same cloud account, so a routine you create in one shows up in the others immediately.
+
+- **Web**: Visit [claude.ai/code/routines](https://claude.ai/code/routines) and click **New routine**
+- **Desktop**: Click **Routines** in the sidebar, click **New routine**, choose **Remote** (choosing **Local** instead creates a Desktop scheduled task)
+- **CLI**: Run `/schedule` in any session. Claude walks through setup conversationally. You can also pass a description: `/schedule daily PR review at 9am`. The CLI creates scheduled-trigger routines only; add API or GitHub triggers from the web.
 
 ### Configuration
 
 | Field        | Description                                                              |
 | ------------ | ------------------------------------------------------------------------ |
-| Name         | Descriptive identifier for the task                                      |
+| Name         | Descriptive identifier for the routine                                   |
 | Prompt       | Instructions sent to Claude each run (must be self-contained)            |
 | Model        | Model used for each run                                                  |
 | Repositories | GitHub repositories to clone (starts from default branch each run)       |
 | Environment  | Cloud environment (network access, env vars, setup script)               |
-| Schedule     | Frequency: Hourly, Daily, Weekdays, or Weekly                            |
+| Triggers     | One or more of: Schedule, API, GitHub event                              |
 | Connectors   | MCP connectors for external services (Slack, Linear, Google Drive, etc.) |
 
 ### Branch Permissions
 
 By default, Claude can only push to branches prefixed with `claude/`. Enable **Allow unrestricted branch pushes** per repository to remove this restriction.
 
-### Frequency Options
+### Schedule Trigger Options
 
 | Frequency | Description                                      |
 | --------- | ------------------------------------------------ |
@@ -68,22 +80,56 @@ By default, Claude can only push to branches prefixed with `claude/`. Enable **A
 | Daily     | Once per day at specified time (default 9:00 AM) |
 | Weekdays  | Same as Daily but skips Saturday and Sunday      |
 | Weekly    | Once per week on specified day and time          |
+| One-off   | Single fire at a specific future timestamp       |
 
 For custom intervals (every 2 hours, first of each month), pick the closest preset and update from CLI with `/schedule update` to set a specific cron expression. Minimum interval is 1 hour.
 
-Tasks may run a few minutes after their scheduled time. The offset is consistent per task.
+Times are entered in your local zone and converted automatically. Runs may start a few minutes after the scheduled time due to stagger; the offset is consistent per routine.
 
-### Managing Cloud Tasks
+One-off runs auto-disable after firing and do not count against the daily routine run cap.
 
-From the task detail page:
+### API Trigger
 
-- **Run now**: Trigger immediately without waiting for schedule
+An API trigger gives a routine a dedicated HTTP endpoint. POSTing to the endpoint with the routine's bearer token starts a new session and returns a session URL. Useful for wiring Claude Code into alerting systems, deploy pipelines, or any tool that can make an authenticated HTTP request.
+
+API triggers are added from the web only; the CLI cannot create or revoke tokens. The endpoint requires the `experimental-cc-routine-2026-04-01` beta header during research preview.
+
+```bash
+curl -X POST https://api.anthropic.com/v1/claude_code/routines/trig_<id>/fire \
+  -H "Authorization: Bearer sk-ant-oat01-xxxxx" \
+  -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Sentry alert SEN-4521 fired in prod."}'
+```
+
+The optional `text` field is freeform per-run context passed to the routine alongside its saved prompt. Each routine has its own token, scoped to triggering that routine only.
+
+### GitHub Trigger
+
+A GitHub trigger starts a new session automatically when a matching event occurs on a connected repository. Each matching event starts its own session.
+
+- **Supported events**: Pull request (opened, closed, assigned, labeled, synchronized, etc.) and Release (created, published, edited, deleted)
+- **Filters**: Author, title, body, base branch, head branch, labels, draft state, merged state. Operators: equals, contains, starts with, is one of, is not one of, matches regex
+- **Setup**: Requires the Claude GitHub App installed on the target repository. `/web-setup` grants clone access but does NOT install the GitHub App; the trigger setup flow prompts for it.
+
+GitHub triggers are configured from the web UI only.
+
+### Managing Routines
+
+From the routine detail page:
+
+- **Run now**: Trigger immediately without waiting for the next scheduled time
 - **Toggle repeats**: Pause/resume without deleting
-- **Edit**: Change prompt, schedule, repositories, environment, or connectors
+- **Edit**: Change name, prompt, schedule, repositories, environment, connectors, or any of the routine's triggers
 - **View runs**: Each run creates a session where you can review changes and create PRs
-- **Delete**: Remove the task (past sessions remain)
+- **Delete**: Remove the routine (past sessions remain)
 
 CLI management: `/schedule list`, `/schedule update`, `/schedule run`
+
+### Usage and Limits
+
+Routines draw down subscription usage like interactive sessions, plus a per-account daily cap on how many runs can start. One-off runs are exempt from the daily cap. Organizations with extra usage enabled can keep running routines on metered overage when the cap is hit. GitHub webhook events are subject to per-routine and per-account hourly caps during research preview.
 
 ## Desktop Scheduled Tasks
 
@@ -249,8 +295,9 @@ Day-of-week: `0` or `7` for Sunday through `6` for Saturday. Extended syntax (`L
 
 ## Sources
 
-- [Cloud Scheduled Tasks](https://code.claude.com/docs/en/web-scheduled-tasks)
+- [Routines](https://code.claude.com/docs/en/routines) (formerly Cloud Scheduled Tasks; old `web-scheduled-tasks` URL redirects here)
 - [Desktop Scheduled Tasks](https://code.claude.com/docs/en/desktop-scheduled-tasks)
 - [CLI Scheduled Tasks (/loop)](https://code.claude.com/docs/en/scheduled-tasks)
+- [Trigger a routine via API](https://platform.claude.com/docs/en/api/claude-code/routines-fire)
 - [GitHub Actions](https://code.claude.com/docs/en/github-actions)
 - [Channels](https://code.claude.com/docs/en/channels)

--- a/features/scheduled-tasks.md
+++ b/features/scheduled-tasks.md
@@ -262,7 +262,7 @@ Each task has an 8-character ID. A session can hold up to 50 scheduled tasks.
 
 ### Seven-Day Expiry
 
-Recurring tasks automatically expire 7 days after creation. The task fires one final time, then deletes itself. This bounds how long a forgotten loop can run. Cancel and recreate before expiry if needed, or use Cloud/Desktop tasks for durable scheduling.
+Recurring tasks automatically expire 7 days after creation. The task fires one final time, then deletes itself. This bounds how long a forgotten loop can run. Cancel and recreate before expiry if needed, or use Routines or Desktop tasks for durable scheduling.
 
 ### Disabling Session Scheduling
 
@@ -270,7 +270,7 @@ Set `CLAUDE_CODE_DISABLE_CRON=1` to disable the scheduler entirely. The cron too
 
 ## Cron Expression Reference
 
-`CronCreate` and cloud tasks accept standard 5-field cron expressions: `minute hour day-of-month month day-of-week`.
+`CronCreate` and Routines accept standard 5-field cron expressions: `minute hour day-of-month month day-of-week`.
 
 | Example        | Meaning                      |
 | -------------- | ---------------------------- |


### PR DESCRIPTION
## Summary

Anthropic rebranded the cloud-side scheduled-tasks product to **Routines** (the canonical URL `/en/web-scheduled-tasks` now redirects to `/en/routines`). This PR updates `features/scheduled-tasks.md` and `README.md` to match the new terminology, and rebuilds the Routines section to reflect the three-trigger-type model (Schedule, API, GitHub) Anthropic now uses.

Closes #192.

## Investigation findings (from upstream)

Read directly from `code.claude.com/docs/en/routines`:

- **Product name**: "Routines" (proper noun, capitalized when used as the product name; "a routine" / "the routine" lowercase as common noun)
- **Page tagline**: "Put Claude Code on autopilot. Define routines that run on a schedule, trigger on API calls, or react to GitHub events from Anthropic-managed cloud infrastructure."
- **Core concept**: A routine is a saved configuration (prompt, repos, environment, connectors); triggers attach to it
- **Three trigger types**: Schedule (recurring or one-off), API (per-routine `/fire` endpoint), GitHub (PR / Release events)
- **Verbs**: "create a routine", "run a routine", "trigger a routine", "fire a routine"
- **Web URL**: `claude.ai/code/routines`
- **CLI**: `/schedule` is still the command (creates scheduled-trigger routines only; API/GitHub triggers added from the web)
- **Status**: Research preview, behind `experimental-cc-routine-2026-04-01` beta header for API trigger
- **Old name**: Upstream doc explicitly mentions the rename and the `/en/desktop-scheduled-tasks` doc is now a separate product (the local variant)

## Decisions

| Decision | Choice | Reason |
| -------- | ------ | ------ |
| Doc filename / slug | KEEP `features/scheduled-tasks.md` (no rename) | The doc covers three scheduling options (Routines, Desktop, /loop) as a comparison reference. "scheduled-tasks" is still an apt umbrella term, and URL stability beats upstream-URL parity for one of three sections. |
| Rebrand aggressiveness | Surgical | Renamed the "Cloud" axis to "Routines (cloud)", rebuilt the Routines section to accurately reflect the three-trigger-type model, kept the Desktop and `/loop` sections intact. The comparison-doc structure is preserved. |
| Cross-references | Update inline README mentions, keep umbrella titles | README's row title "Scheduled Tasks" stays (the linked doc covers three things), but inline phrases like "Cloud cron jobs" and "Cloud tasks (cron) via claude.ai" were updated to "Routines (cloud)" and "Routines via claude.ai". |

## What was renamed

### `features/scheduled-tasks.md`

- Frontmatter `description` (line 3): clarifies "Routines (cloud)" alongside desktop and `/loop`
- Comparison table column header (line 13): `Cloud` → `Routines (cloud)`
- "When to use which" bullet (line 27): `Cloud tasks` → `Routines`, with mention of API/GitHub triggers
- Section heading (line 31): `## Cloud Scheduled Tasks` → `## Routines (Cloud)`
- New intro paragraph (line 33) defines a routine using upstream wording
- New explicit rebrand note (line 35) so readers landing here from old links know what changed
- Restructured Routines subsections to introduce the three trigger types as a first-class concept:
  - New `### Trigger Types` table
  - Renamed `### Frequency Options` to `### Schedule Trigger Options`, added one-off row
  - New `### API Trigger` subsection with curl example and beta header note
  - New `### GitHub Trigger` subsection with supported events and filter list
  - New `### Usage and Limits` subsection covering daily run cap and one-off exemption
- Sources list (line 252): primary link is now [Routines](https://code.claude.com/docs/en/routines), added link to the routine-fire API reference, kept Desktop / `/loop` source links intact

### `README.md`

- Line 33 (feature index table): `Cloud cron jobs, desktop tasks, CLI loops` → `Routines (cloud), desktop tasks, CLI loops`
- Line 580 (Scheduled Tasks key capabilities): `Cloud tasks (cron) via claude.ai for Team/Enterprise` → `Routines via claude.ai (cloud, schedule/API/GitHub triggers, Pro and above)`

## What was NOT renamed and why

- **Doc filename / slug** (`features/scheduled-tasks.md`): URL stability for inbound links beats parity with one of three sections.
- **Section "Desktop Scheduled Tasks"** and the "Desktop" axis: Upstream still calls this "Desktop scheduled tasks" (separate product at `/en/desktop-scheduled-tasks`), so this is left intact.
- **CLI Session-Scoped Scheduling section** (`/loop`, CronCreate / CronList / CronDelete): Local terminal scheduler, completely unrelated to Anthropic's Routines rebrand.
- **README umbrella row title "Scheduled Tasks"**: The linked doc still covers three scheduling options, so this remains an accurate umbrella label.
- **Quick Reference / Feature Comparison Matrix rows for "Scheduled Tasks"** in README: unchanged, since the row aggregates across all three options.

## Cross-references updated

- `README.md` line 33 (feature index)
- `README.md` line 580 (Scheduled Tasks section "Key Capabilities" bullet)

No other docs in the repo reference `scheduled-tasks.md` by URL, slug, or by the old "Cloud Scheduled Tasks" terminology (verified via `grep -rn 'scheduled-tasks\|Scheduled Tasks\|cloud scheduled\|Cloud Scheduled'`).

## Verification

- mdformat strict pass: clean (`pre-commit run --files features/scheduled-tasks.md README.md` → all hooks Passed)
- Em-dash sweep on diff: 0 occurrences
- Diff stats: 2 files changed, 70 insertions(+), 23 deletions(-)

## Test plan

- [ ] Skim `features/scheduled-tasks.md` rendered on the docs site to confirm the new Trigger Types / API Trigger / GitHub Trigger subsections read cleanly under their headings
- [ ] Confirm README cross-links to `features/scheduled-tasks.md` still resolve
- [ ] Verify the rebrand-note callout reads correctly to a reader landing from an old `web-scheduled-tasks` bookmark