### PR TITLE
docs: post-rename cleanup for additional-features and ultraplan

### DIFF
--- a/features/additional-features.md
+++ b/features/additional-features.md
@@ -320,7 +320,7 @@ Native desktop app with GUI.
 
 ______________________________________________________________________
 
-## Remote Development
+## Isolated Environments
 
 ### DevContainers
 

--- a/features/ultraplan.md
+++ b/features/ultraplan.md
@@ -46,7 +46,7 @@ If Remote Control is active, it disconnects when ultraplan starts (both features
 
 ## Status Indicators
 
-After launch, your CLI prompt shows a status indicator while the remote session works:
+After launch, your CLI prompt shows a status indicator while the Remote session works:
 
 | Status                       | Meaning                                                            |
 | ---------------------------- | ------------------------------------------------------------------ |


### PR DESCRIPTION
## Summary

Two minor post-rename cleanup items surfaced by `pr191-cross` during PR #191 review but excluded from that PR's surgical scope.

## Changes

### `features/additional-features.md` L323: heading collision fix

PR #191 changed L316 to "Launch Local or Remote sessions" (capitalized "Remote" as the Anthropic-managed VM proper noun). That sat ~6 lines above the existing `## Remote Development` heading at L323, which used "Remote" in a different sense (remote-host workflows covering DevContainers + Web Sessions). Two senses of "Remote" close together caused reader confusion.

**Decision: Option A** — rename `## Remote Development` to `## Isolated Environments`.

Rationale: the section groups DevContainers (local isolated env) and Web Sessions (Remote VM, also isolated). "Isolated Environments" describes both accurately, avoids "Remote" entirely (eliminating the collision), and matches existing vocabulary in the docs (`README.md` "Sandboxed execution in isolated containers", `gitlab-cicd.md` "Each interaction runs in an isolated container").

**Inbound anchor audit**: `grep -rn '#remote-development'` returned zero hits, so the slug change is non-invasive. The other "Remote Development" mention in `ide-integrations.md:114` is unrelated (JetBrains plugin context) and was left as-is.

### `features/ultraplan.md` L51: capitalize "remote session"

```diff
-After launch, your CLI prompt shows a status indicator while the remote session works:
+After launch, your CLI prompt shows a status indicator while the Remote session works:
```

Pre-existing inconsistency with the rest of the doc, which uses capitalized "Remote" as the proper-noun env label per PR #189 phase-1 + PR #191 phase-2.

## Test plan

- [x] Visual diff review of both edits
- [x] `grep '#remote-development'` shows no inbound anchor breakage
- [x] `pre-commit run mdformat --files features/additional-features.md features/ultraplan.md` passes
- [x] No em-dashes introduced (grep clean)
- [ ] CI checks pass on the PR