### PR TITLE
feat(site): markdown discovery hints (Link header, HTML alternate, X-Robots-Tag)

### DIFF
--- a/site/functions/_middleware.ts
+++ b/site/functions/_middleware.ts
@@ -243,8 +243,11 @@ export const onRequest: PagesFunction = async ({
     // we can advertise it via a Link header (RFC 8288). Agents that parse
     // Link headers can discover the markdown variant without prior
     // knowledge of llms.txt or content negotiation.
+    //
+    // Only emit the Link on 200 responses. Pointing agents at a markdown
+    // alternate from a 404 or 5xx upstream is misleading.
     let markdownAlternate: string | null = null;
-    if (path.startsWith('/docs/')) {
+    if (path.startsWith('/docs/') && response.status === 200) {
       const slug = path.replace(/^\/docs\/?/, '').replace(/\/$/, '');
       if (slug && /^[a-z0-9-]+$/.test(slug)) {
         markdownAlternate = `/llms.mdx/docs/${slug}/content.md`;

--- a/site/functions/_middleware.ts
+++ b/site/functions/_middleware.ts
@@ -149,6 +149,10 @@ function markdownResponse(
     'Content-Type': 'text/markdown; charset=utf-8',
     'X-Markdown-Tokens': estimatedTokens.toString(),
     Vary: 'Accept',
+    // Prevent search engines from indexing the markdown variant. The HTML
+    // version is canonical; markdown is served only for content negotiation
+    // and would otherwise create duplicate-content noise.
+    'X-Robots-Tag': 'noindex, nofollow',
   };
   if (extraCache) {
     // Only cache successful content — errors should stay fresh.
@@ -235,18 +239,40 @@ export const onRequest: PagesFunction = async ({
       trackRequest(env, request, path, 'html', elapsed, response.status, null),
     );
 
-    // Set device_id cookie on HTML responses if not already present.
-    // Build a fresh Headers object from response.headers instead of passing
-    // the upstream Response as the init — the init-object form aliases the
-    // headers, and mutating shared headers on a streaming response is what
-    // triggered the Safari sub-resource failure above.
-    if (!getDeviceIdCookie(request)) {
-      const id = crypto.randomUUID();
+    // Compute the markdown alternate URL for /docs/<slug> HTML responses so
+    // we can advertise it via a Link header (RFC 8288). Agents that parse
+    // Link headers can discover the markdown variant without prior
+    // knowledge of llms.txt or content negotiation.
+    let markdownAlternate: string | null = null;
+    if (path.startsWith('/docs/')) {
+      const slug = path.replace(/^\/docs\/?/, '').replace(/\/$/, '');
+      if (slug && /^[a-z0-9-]+$/.test(slug)) {
+        markdownAlternate = `/llms.mdx/docs/${slug}/content.md`;
+      }
+    }
+
+    // Set device_id cookie on HTML responses if not already present, and/or
+    // attach the Link alternate. Build a fresh Headers object from
+    // response.headers instead of passing the upstream Response as the
+    // init: the init-object form aliases the headers, and mutating shared
+    // headers on a streaming response is what triggered the Safari
+    // sub-resource failure above.
+    const needsCookie = !getDeviceIdCookie(request);
+    if (needsCookie || markdownAlternate) {
       const headers = new Headers(response.headers);
-      headers.append(
-        'Set-Cookie',
-        `device_id=${id}; Path=/; HttpOnly; SameSite=Lax; Max-Age=31536000`,
-      );
+      if (needsCookie) {
+        const id = crypto.randomUUID();
+        headers.append(
+          'Set-Cookie',
+          `device_id=${id}; Path=/; HttpOnly; SameSite=Lax; Max-Age=31536000`,
+        );
+      }
+      if (markdownAlternate) {
+        headers.append(
+          'Link',
+          `<${markdownAlternate}>; rel="alternate"; type="text/markdown"`,
+        );
+      }
       return new Response(response.body, {
         status: response.status,
         statusText: response.statusText,

--- a/site/public/_headers
+++ b/site/public/_headers
@@ -8,9 +8,15 @@
 
 /llms.txt
   Access-Control-Allow-Origin: *
+  X-Robots-Tag: noindex, nofollow
 
 /llms-full.txt
   Access-Control-Allow-Origin: *
+  X-Robots-Tag: noindex, nofollow
 
 /llms.mdx/*
   Access-Control-Allow-Origin: *
+  X-Robots-Tag: noindex, nofollow
+
+/*.md
+  X-Robots-Tag: noindex, nofollow

--- a/site/src/app/docs/[[...slug]]/page.tsx
+++ b/site/src/app/docs/[[...slug]]/page.tsx
@@ -140,5 +140,14 @@ export async function generateMetadata(props: PageProps<'/docs/[[...slug]]'>): P
     openGraph: {
       images: getPageImage(page).url,
     },
+    // Advertise the markdown representation in the HTML head so agents
+    // that parse HTML but don't inspect response headers can discover
+    // the markdown variant. Mirrors the Link header set by the Pages
+    // middleware on HTML responses.
+    alternates: {
+      types: {
+        'text/markdown': getPageMarkdownUrl(page).url,
+      },
+    },
   };
 }

--- a/site/src/app/docs/[[...slug]]/page.tsx
+++ b/site/src/app/docs/[[...slug]]/page.tsx
@@ -144,8 +144,14 @@ export async function generateMetadata(props: PageProps<'/docs/[[...slug]]'>): P
     // that parse HTML but don't inspect response headers can discover
     // the markdown variant. Mirrors the Link header set by the Pages
     // middleware on HTML responses.
+    //
+    // Next.js mergeMetadata replaces alternates wholesale rather than
+    // deep-merging types, so the atom feed alternate from layout.tsx
+    // (the source of truth) must be re-declared here to survive on
+    // /docs/<slug> pages.
     alternates: {
       types: {
+        'application/atom+xml': '/feed.xml',
         'text/markdown': getPageMarkdownUrl(page).url,
       },
     },


### PR DESCRIPTION
## Summary

Bundles three small, related changes that make the markdown variant of `/docs/<slug>` pages discoverable by AI agents that don't already know to send `Accept: text/markdown`.

- **#150** — Pages middleware now sets `Link: </llms.mdx/docs/<slug>/content.md>; rel="alternate"; type="text/markdown"` on HTML responses for `/docs/<slug>` (RFC 8288). Agents that parse Link headers can discover the markdown variant without prior knowledge of llms.txt or content negotiation.
- **#151** — `/docs/<slug>` HTML pages now include `<link rel="alternate" type="text/markdown" href="/llms.mdx/docs/<slug>/content.md">` in the head, emitted via Next.js `Metadata.alternates.types` from `generateMetadata`. Mirrors the Link header for agents that parse HTML but not response headers.
- **#152** — Markdown responses (`/llms.txt`, `/llms-full.txt`, `/home.md`, `/llms.mdx/docs/.../content.md`, markdown 404) now carry `X-Robots-Tag: noindex, nofollow` so search engines don't index the markdown variant alongside the HTML canonical.

## Files changed

- `site/functions/_middleware.ts`
  - In the non-markdown `next()` fallthrough: compute markdown alternate URL when path matches `/docs/<slug>` (with the same `[a-z0-9-]+` slug guard already used for content negotiation), append `Link` header.
  - Combined the cookie-set and Link-set paths so the response is rewrapped at most once.
  - In `markdownResponse()` helper: added `X-Robots-Tag: noindex, nofollow` to the always-set headers map.
- `site/src/app/docs/[[...slug]]/page.tsx`
  - Added `alternates: { types: { 'text/markdown': getPageMarkdownUrl(page).url } }` to the `generateMetadata` return value. `getPageMarkdownUrl` already produces `/llms.mdx/docs/<slug>/content.md` (verified in `site/src/lib/source.ts` and `site/src/lib/shared.ts`).

## Notes

- The alternate URL pattern `/llms.mdx/docs/<slug>/content.md` matches the existing content-negotiation route and the Fumadocs source helper, so middleware and HTML head agree.
- No existing canonical link tag in the head, so the new alternate-only link is additive and does not conflict.
- `mdformat` not relevant (no markdown content files touched).

## Test plan

- [x] `cd site && npm run build` succeeds locally
- [x] Static-rendered `/docs/agents` HTML contains `<link rel="alternate" type="text/markdown" href="/llms.mdx/docs/agents/content.md">`
- [ ] CI green
- [ ] Post-merge: `curl -sI https://claude-almanac.sivura.com/docs/agents | grep -i ^link` shows the `Link` header
- [ ] Post-merge: `curl -sI -H 'Accept: text/markdown' https://claude-almanac.sivura.com/llms.txt | grep -i x-robots-tag` shows `noindex, nofollow`
- [ ] Post-merge: view-source on a docs page shows the alternate `<link>` tag in the head

Closes #150
Closes #151
Closes #152