### PR TITLE
docs: document CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD env var

### DIFF
--- a/features/memory-context.md
+++ b/features/memory-context.md
@@ -61,6 +61,22 @@ Claude Code discovers CLAUDE.md files using both **upward** and **downward** tra
 - Prevents context bloat in large monorepos with many packages
 - Ensures you get relevant context without overwhelming the context window
 
+### Loading Memory from Additional Directories
+
+By default, directories added via `--add-dir`, `/add-dir`, or the `additionalDirectories` setting extend Claude Code's **file access** only. Their `CLAUDE.md` and `CLAUDE.local.md` files are not loaded — only the memory files discovered by walking up from the current working directory are included.
+
+Starting in Claude Code **2.1.20**, an opt-in environment variable enables memory loading from additional directories:
+
+```bash
+export CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1
+```
+
+When set, Claude Code loads `CLAUDE.md` and `CLAUDE.local.md` from every directory in the additional directories list at startup, in addition to the cwd upward chain. The variable is opt-in to preserve backward compatibility for users with large `additionalDirectories` lists.
+
+**Trade-off:** all matched memory files are loaded at startup, so the context cost scales with the number of added directories. This works well for a small, curated set of directories (a handful of related repos or a monorepo). Exporting it globally with a large `additionalDirectories` list may consume significant context budget before any conversation begins. Consider setting it per-session rather than in a shell profile.
+
+This environment variable is currently undocumented in the official Claude Code reference pages.
+
 ### Memory Imports
 
 CLAUDE.md files can import other files:
@@ -457,3 +473,5 @@ Official Anthropic guidance and community best practices for CLAUDE.md formattin
 - [Memory Management](https://code.claude.com/docs/en/memory)
 - [Best Practices](https://code.claude.com/docs/en/best-practices)
 - [Context Management](https://code.claude.com/docs/en/interactive-mode)
+- [CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD (GitHub issue #21138)](https://github.com/anthropics/claude-code/issues/21138)
+- [Feature request: load CLAUDE.md from additionalDirectories (GitHub issue #12259)](https://github.com/anthropics/claude-code/issues/12259)

--- a/guides/multi-project-workspace.md
+++ b/guides/multi-project-workspace.md
@@ -162,7 +162,7 @@ Ghostty launcher (ghostty-claude.sh)
 ## Tips
 
 - **One workspace, many sessions**: you can press Ctrl+Shift+T multiple times to launch separate Claude sessions for different projects. Each gets its own Ghostty window and tmux session.
-- **Project-specific CLAUDE.md**: each project can have its own `CLAUDE.md` with specific conventions. Claude reads the one from the working directory it was launched in.
+- **Project-specific CLAUDE.md**: each project can have its own `CLAUDE.md` with specific conventions. Claude reads the one from the working directory it was launched in. By default, directories in `additionalDirectories` grant file access only — their `CLAUDE.md` files are not loaded. To opt in to loading `CLAUDE.md` and `CLAUDE.local.md` from every additional directory, set `CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1` before starting a session. Note that this loads all of them at startup, so for a large `additionalDirectories` list the context cost can be significant — set it per session rather than exporting it globally. See [Memory & Context](../features/memory-context.md) for details.
 - **Global rules via `~/.claude/rules/`**: rules that apply across all projects (commit conventions, personal preferences) go in your global rules directory.
 - **Adding projects**: when you add a new project, update both the `.code-workspace` file and `additionalDirectories` in `settings.json`.
 


### PR DESCRIPTION
## Summary

- Add `### Loading Memory from Additional Directories` subsection to `features/memory-context.md` documenting the opt-in `CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1` env var introduced in Claude Code 2.1.20
- Explain the default behavior (additional dirs = file access only, no memory loading), how to enable it, and the context-cost trade-off for large `additionalDirectories` lists
- Add a short note in `guides/multi-project-workspace.md` pointing users to the env var with a cross-link to the reference doc
- Add issue references to the Sources section

## Sources

- [CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD (GitHub issue #21138)](https://github.com/anthropics/claude-code/issues/21138)
- [Feature request: load CLAUDE.md from additionalDirectories (GitHub issue #12259)](https://github.com/anthropics/claude-code/issues/12259)